### PR TITLE
feat: implement escalated notifications

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalationPolicy: data?.escalationPolicy || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useEffect } from "react";
 import { logger } from "@/Utils/logger";
 import { useParams, useLocation, useNavigate } from "react-router";
-import { useForm, Controller } from "react-hook-form";
+import { useForm, Controller, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTheme } from "@mui/material";
 import Stack from "@mui/material/Stack";
@@ -14,7 +14,7 @@ import Typography from "@mui/material/Typography";
 import Link from "@mui/material/Link";
 import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
-import { Trash2 } from "lucide-react";
+import { Trash2, Plus } from "lucide-react";
 import { HeaderDeleteControls } from "@/Components/monitors";
 import { GeoContinents } from "@/Types/GeoCheck";
 
@@ -203,6 +203,15 @@ const CreateMonitorPage = () => {
 		defaultValues: defaults,
 	});
 	const { control, watch, handleSubmit, clearErrors } = form;
+
+	const {
+		fields: escalationFields,
+		append: appendEscalation,
+		remove: removeEscalation,
+	} = useFieldArray({
+		control,
+		name: "escalationPolicy",
+	});
 
 	useEffect(() => {
 		form.reset(defaults);
@@ -762,6 +771,113 @@ const CreateMonitorPage = () => {
 							);
 						}}
 					/>
+				}
+			/>
+
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalation.title")}
+				subtitle={t("pages.createMonitor.form.escalation.description")}
+				rightContent={
+					<Stack spacing={theme.spacing(LAYOUT.MD)}>
+						{escalationFields.map((field, index) => (
+							<Stack
+								key={field.id}
+								direction="row"
+								alignItems="flex-start"
+								spacing={theme.spacing(SPACING.LG)}
+								sx={{
+									p: theme.spacing(SPACING.LG),
+									border: `1px solid ${theme.palette.divider}`,
+									borderRadius: theme.shape.borderRadius,
+								}}
+							>
+								<Typography
+									sx={{
+										minWidth: "60px",
+										pt: "8px",
+										fontWeight: 600,
+									}}
+								>
+									{t("pages.createMonitor.form.escalation.level", {
+										level: index + 1,
+									})}
+								</Typography>
+								<Controller
+									name={`escalationPolicy.${index}.waitTime`}
+									control={control}
+									render={({ field: f, fieldState }) => (
+										<TextField
+											{...f}
+											value={f.value === 0 ? "" : f.value}
+											onChange={(e) => {
+												const val = e.target.value;
+												f.onChange(val === "" ? 0 : Number(val));
+											}}
+											type="number"
+											fieldLabel={t(
+												"pages.createMonitor.form.escalation.option.waitTime.label"
+											)}
+											placeholder={t(
+												"pages.createMonitor.form.escalation.option.waitTime.placeholder"
+											)}
+											error={!!fieldState.error}
+											helperText={fieldState.error?.message ?? ""}
+											sx={{ flex: 1 }}
+										/>
+									)}
+								/>
+								<Controller
+									name={`escalationPolicy.${index}.notificationId`}
+									control={control}
+									render={({ field: f, fieldState }) => {
+										const notificationOptions = (notifications ?? []).map((n) => ({
+											...n,
+											name: n.notificationName,
+										}));
+										const selectedNotification = notificationOptions.find(
+											(n) => n.id === f.value
+										);
+										return (
+											<Autocomplete
+												options={notificationOptions}
+												value={selectedNotification ?? null}
+												getOptionLabel={(option) => option.name}
+												onChange={(
+													_: unknown,
+													newValue: (typeof notificationOptions)[number] | null
+												) => {
+													f.onChange(newValue?.id ?? "");
+												}}
+												isOptionEqualToValue={(option, value) => option.id === value.id}
+												fieldLabel={t(
+													"pages.createMonitor.form.escalation.option.notification.label"
+												)}
+												sx={{ flex: 2 }}
+											/>
+										);
+									}}
+								/>
+								<IconButton
+									size="small"
+									onClick={() => removeEscalation(index)}
+									aria-label={t("pages.createMonitor.form.escalation.remove")}
+									sx={{ mt: "28px" }}
+								>
+									<Trash2 size={16} />
+								</IconButton>
+							</Stack>
+						))}
+						<Button
+							variant="outlined"
+							onClick={() => appendEscalation({ waitTime: 0, notificationId: "" })}
+							sx={{ alignSelf: "flex-start" }}
+						>
+							<Plus size={16} />
+							<Typography sx={{ ml: 1 }}>
+								{t("pages.createMonitor.form.escalation.addLevel")}
+							</Typography>
+						</Button>
+					</Stack>
 				}
 			/>
 

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface EscalationLevel {
+	waitTime: number;
+	notificationId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +65,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationPolicy?: EscalationLevel[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -1,8 +1,15 @@
 import { z } from "zod";
 import { GeoContinents } from "@/Types/GeoCheck";
 
-// URL schema with custom error message
 const urlSchema = z.url({ message: "Please enter a valid URL" });
+
+const escalationLevelSchema = z.object({
+	waitTime: z
+		.number()
+		.min(1, "Wait time must be at least 1 minute")
+		.max(1440, "Wait time must be at most 1440 minutes (24 hours)"),
+	notificationId: z.string().min(1, "Notification channel is required"),
+});
 
 // Common base schema for all monitor types
 const baseSchema = z.object({
@@ -13,6 +20,7 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalationPolicy: z.array(escalationLevelSchema).max(10).optional(),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -543,6 +543,23 @@
 					"description": "Select the notification channels you want to use",
 					"title": "Notifications"
 				},
+				"escalation": {
+					"title": "Escalated Notifications",
+					"description": "Configure escalation levels to notify different channels as an incident persists over time",
+					"addLevel": "Add escalation level",
+					"level": "Level {{level}}",
+					"option": {
+						"waitTime": {
+							"label": "Wait time (minutes)",
+							"placeholder": "Minutes after incident starts"
+						},
+						"notification": {
+							"label": "Notification channel",
+							"placeholder": "Select a notification channel"
+						}
+					},
+					"remove": "Remove escalation level"
+				},
 				"type": {
 					"description": "Select the type of check to perform",
 					"optionDockerDescription": "Use Docker to monitor if a container is running.",

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -72,6 +72,10 @@ const IncidentSchema = new Schema<IncidentDocument>(
 			type: String,
 			default: null,
 		},
+		escalationsSent: {
+			type: [Number],
+			default: [],
+		},
 	},
 	{ timestamps: true }
 );

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -18,11 +18,12 @@ type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Dat
 
 type MonitorDocumentBase = Omit<
 	Monitor,
-	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
+	"id" | "userId" | "teamId" | "notifications" | "escalationPolicy" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
 > & {
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
+	escalationPolicy: { waitTime: number; notificationId: Types.ObjectId }[];
 	selectedDisks: string[];
 	matchMethod?: MonitorMatchMethod;
 };
@@ -284,6 +285,19 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalationPolicy: {
+			type: [
+				{
+					waitTime: { type: Number, required: true },
+					notificationId: {
+						type: Schema.Types.ObjectId,
+						ref: "Notification",
+						required: true,
+					},
+				},
+			],
+			default: [],
+		},
 		secret: {
 			type: String,
 		},

--- a/server/src/repositories/incidents/MongoIncidentRepository.ts
+++ b/server/src/repositories/incidents/MongoIncidentRepository.ts
@@ -60,6 +60,7 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			resolvedBy: doc.resolvedBy ? this.toStringId(doc.resolvedBy) : null,
 			resolvedByEmail: doc.resolvedByEmail ?? null,
 			comment: doc.comment ?? null,
+			escalationsSent: doc.escalationsSent ?? [],
 			createdAt: this.toDateString(doc.createdAt),
 			updatedAt: this.toDateString(doc.updatedAt),
 		};

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -374,6 +374,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalationPolicy: (doc.escalationPolicy ?? []).map((level) => ({
+				waitTime: level.waitTime,
+				notificationId: toStringId(level.notificationId),
+			})),
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -433,6 +437,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalationPolicy: (doc.escalationPolicy ?? []).map((level: { waitTime: number; notificationId: unknown }) => ({
+				waitTime: level.waitTime,
+				notificationId: toStringId(level.notificationId),
+			})),
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -512,7 +512,7 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 			notificationReason: null,
 		};
 
-		if (!statusChanged) {
+		if (!statusChanged && !(prevStatus === "initializing" && (monitor.status === "down" || monitor.status === "breached"))) {
 			return decision;
 		}
 

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -168,6 +168,22 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 					});
 				}
 
+				if (
+					!statusChangeResult.statusChanged &&
+					(statusChangeResult.monitor.status === "down" || statusChangeResult.monitor.status === "breached") &&
+					statusChangeResult.monitor.escalationPolicy &&
+					statusChangeResult.monitor.escalationPolicy.length > 0
+				) {
+					this.handleEscalations(statusChangeResult.monitor).catch((error: unknown) => {
+						this.logger.error({
+							message: `Error handling escalations for monitor ${statusChangeResult.monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+							service: SERVICE_NAME,
+							method: "getMonitorJob",
+							stack: error instanceof Error ? error.stack : undefined,
+						});
+					});
+				}
+
 				// Step 7. Handle incidents (best effort, don't wait)
 				this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status).catch((error: unknown) => {
 					this.logger.warn({
@@ -417,6 +433,72 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 			}
 		};
 	};
+
+	private async handleEscalations(monitor: Monitor): Promise<void> {
+		const escalationPolicy = monitor.escalationPolicy;
+		if (!escalationPolicy || escalationPolicy.length === 0) {
+			return;
+		}
+
+		let activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId);
+
+		if (!activeIncident) {
+			this.logger.info({
+				message: `No active incident found for down monitor ${monitor.id}, creating one for escalation tracking`,
+				service: SERVICE_NAME,
+				method: "handleEscalations",
+			});
+			activeIncident = await this.incidentsRepository.create({
+				monitorId: monitor.id,
+				teamId: monitor.teamId,
+				startTime: new Date().toISOString(),
+				status: true,
+				statusCode: 0,
+			});
+		}
+
+		const incidentStartTime = new Date(activeIncident.startTime).getTime();
+		const now = Date.now();
+		const incidentDurationMinutes = Math.floor((now - incidentStartTime) / (1000 * 60));
+		const escalationsSent = activeIncident.escalationsSent || [];
+
+		for (let i = 0; i < escalationPolicy.length; i++) {
+			const level = escalationPolicy[i]!;
+			if (escalationsSent.includes(i)) {
+				continue;
+			}
+
+			if (incidentDurationMinutes >= level.waitTime) {
+				this.logger.info({
+					message: `Sending escalation level ${i + 1} for monitor ${monitor.id} (incident duration: ${incidentDurationMinutes}m, trigger: ${level.waitTime}m)`,
+					service: SERVICE_NAME,
+					method: "handleEscalations",
+				});
+
+				try {
+					await this.notificationsService.sendEscalationNotification(monitor, level.notificationId, i, level.waitTime, incidentDurationMinutes);
+
+					const updatedEscalationsSent = [...escalationsSent, i];
+					await this.incidentsRepository.updateById(activeIncident.id, monitor.teamId, {
+						escalationsSent: updatedEscalationsSent,
+					});
+
+					this.logger.info({
+						message: `Escalation level ${i + 1} sent successfully for monitor ${monitor.id}`,
+						service: SERVICE_NAME,
+						method: "handleEscalations",
+					});
+				} catch (error: unknown) {
+					this.logger.error({
+						message: `Failed to send escalation level ${i + 1} for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+						service: SERVICE_NAME,
+						method: "handleEscalations",
+						stack: error instanceof Error ? error.stack : undefined,
+					});
+				}
+			}
+		}
+	}
 
 	private evaluateMonitorAction(statusChangeResult: StatusChangeResult): MonitorActionDecision {
 		const { monitor, statusChanged, prevStatus } = statusChangeResult;

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -15,6 +15,13 @@ export interface INotificationMessageBuilder {
 		decision: MonitorActionDecision,
 		clientHost: string
 	): NotificationMessage;
+	buildEscalationMessage(
+		monitor: Monitor,
+		escalationLevel: number,
+		waitTime: number,
+		incidentDurationMinutes: number,
+		clientHost: string
+	): NotificationMessage;
 	extractThresholdBreaches(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): ThresholdBreach[];
 }
 
@@ -48,6 +55,48 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 			metadata: {
 				teamId: monitor.teamId,
 				notificationReason: decision.notificationReason || "status_change",
+			},
+		};
+	}
+
+	buildEscalationMessage(
+		monitor: Monitor,
+		escalationLevel: number,
+		waitTime: number,
+		incidentDurationMinutes: number,
+		clientHost: string
+	): NotificationMessage {
+		const title = `Escalation Alert (Level ${escalationLevel + 1}): ${monitor.name}`;
+		const summary = `Monitor "${monitor.name}" has been down for ${incidentDurationMinutes} minutes. This is an escalation notification (Level ${escalationLevel + 1}, triggered after ${waitTime} minutes).`;
+		const details = [
+			`URL: ${monitor.url}`,
+			`Status: Down`,
+			`Type: ${monitor.type}`,
+			`Incident Duration: ${incidentDurationMinutes} minutes`,
+			`Escalation Level: ${escalationLevel + 1}`,
+			`Escalation Trigger: After ${waitTime} minutes`,
+		];
+
+		return {
+			type: "escalation",
+			severity: "critical",
+			monitor: {
+				id: monitor.id,
+				name: monitor.name,
+				url: monitor.url,
+				type: monitor.type,
+				status: monitor.status,
+			},
+			content: {
+				title,
+				summary,
+				details,
+				timestamp: new Date(),
+			},
+			clientHost,
+			metadata: {
+				teamId: monitor.teamId,
+				notificationReason: "escalation",
 			},
 		};
 	}

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -87,6 +87,8 @@ export class EmailProvider implements INotificationProvider {
 				return `Monitor ${message.monitor.name} threshold exceeded`;
 			case "threshold_resolved":
 				return `Monitor ${message.monitor.name} thresholds resolved`;
+			case "escalation":
+				return `ESCALATION: Monitor ${message.monitor.name} is still down`;
 			default:
 				return `Alert: ${message.monitor.name}`;
 		}
@@ -105,13 +107,6 @@ export class EmailProvider implements INotificationProvider {
 			details: message.content.details,
 			incidentUrl: message.content.incident?.url,
 		};
-
-		this.logger.info({
-			message: "[DEBUG] Building email from message",
-			service: SERVICE_NAME,
-			method: "buildEmailFromMessage",
-			details: { context },
-		});
 
 		const html = await this.emailService.buildEmail("unifiedNotificationTemplate", context);
 

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,6 +14,13 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	sendEscalationNotification: (
+		monitor: Monitor,
+		notificationId: string,
+		escalationLevel: number,
+		waitTime: number,
+		incidentDurationMinutes: number
+	) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -139,6 +146,45 @@ export class NotificationsService implements INotificationsService {
 
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	sendEscalationNotification = async (
+		monitor: Monitor,
+		notificationId: string,
+		escalationLevel: number,
+		waitTime: number,
+		incidentDurationMinutes: number
+	): Promise<boolean> => {
+		const notifications = await this.notificationsRepository.findNotificationsByIds([notificationId]);
+		if (notifications.length === 0) {
+			this.logger.warn({
+				message: `Escalation notification not found: ${notificationId}`,
+				service: SERVICE_NAME,
+				method: "sendEscalationNotification",
+			});
+			return false;
+		}
+
+		const notification = notifications[0];
+		if (!notification) {
+			this.logger.warn({
+				message: `Escalation notification lookup returned empty for: ${notificationId}`,
+				service: SERVICE_NAME,
+				method: "sendEscalationNotification",
+			});
+			return false;
+		}
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+		const notificationMessage = this.notificationMessageBuilder.buildEscalationMessage(
+			monitor,
+			escalationLevel,
+			waitTime,
+			incidentDurationMinutes,
+			clientHost
+		);
+
+		return await this.send(notification, monitor, {} as MonitorStatusResponse, {} as MonitorActionDecision, notificationMessage);
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -16,6 +16,7 @@ export interface Incident {
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;
 	comment?: string | null;
+	escalationsSent?: number[];
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface EscalationLevel {
+	waitTime: number;
+	notificationId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +42,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationPolicy?: EscalationLevel[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/types/notificationMessage.ts
+++ b/server/src/types/notificationMessage.ts
@@ -1,9 +1,4 @@
-/**
- * Unified notification message types for cross-provider consistency
- * Part of notification system unification effort
- */
-
-export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test";
+export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "escalation" | "test";
 
 export type NotificationSeverity = "critical" | "warning" | "info" | "success";
 
@@ -20,7 +15,7 @@ export interface ThresholdBreach {
 	currentValue: number;
 	threshold: number;
 	unit: string;
-	formattedValue: string; // e.g., "85%" or "72°C"
+	formattedValue: string;
 }
 
 export interface IncidentInfo {

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -49,6 +49,11 @@ export const getCertificateParamValidation = z.object({
 	monitorId: z.string().min(1, "Monitor ID is required"),
 });
 
+const escalationLevelSchema = z.object({
+	waitTime: z.number().min(1, "Wait time must be at least 1 minute").max(1440, "Wait time must be at most 1440 minutes (24 hours)"),
+	notificationId: z.string().min(1, "Notification ID is required"),
+});
+
 export const createMonitorBodyValidation = z.object({
 	_id: z.string().optional(),
 	name: z.string().min(1, "Name is required"),
@@ -67,6 +72,7 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalationPolicy: z.array(escalationLevelSchema).max(10).optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +95,7 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalationPolicy: z.array(escalationLevelSchema).max(10).optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),


### PR DESCRIPTION
Implements escalated notifications for monitors. Users can add escalation levels with a wait time and notification channel. When a monitor goes down and stays down past the configured wait time, an escalation email gets sent to the assigned channel. Escalation settings persist on reload.