### PR TITLE
(ISSUE #1) Notification escalations feature for monitors

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalation: data?.escalation ?? null,
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -213,6 +213,15 @@ const CreateMonitorPage = () => {
 	const watchedUseAdvancedMatching = watch("useAdvancedMatching") as boolean;
 	const watchGeoCheckEnabled = watch("geoCheckEnabled") as boolean;
 
+	const notificationOptions = useMemo(
+		() =>
+			(notifications ?? []).map((notification) => ({
+				...notification,
+				name: notification.notificationName,
+			})),
+		[notifications]
+	);
+
 	useEffect(() => {
 		clearErrors();
 	}, [watchedType, clearErrors]);
@@ -252,11 +261,19 @@ const CreateMonitorPage = () => {
 	};
 
 	const onSubmit = async (data: MonitorFormData) => {
+		const payload: MonitorFormData = {
+			...data,
+			escalation:
+				data.escalation && data.escalation.channelId && data.escalation.delayMinutes > 0
+					? data.escalation
+					: null,
+		};
+
 		let result;
 		if (isEditMode && monitorId) {
-			result = await patch(`/monitors/${monitorId}`, data);
+			result = await patch(`/monitors/${monitorId}`, payload);
 		} else {
-			result = await post("/monitors", data);
+			result = await post("/monitors", payload);
 		}
 
 		if (result?.success) {
@@ -705,11 +722,6 @@ const CreateMonitorPage = () => {
 						name="notifications"
 						control={control}
 						render={({ field }) => {
-							// Map notifications to have 'name' property for Autocomplete
-							const notificationOptions = (notifications ?? []).map((n) => ({
-								...n,
-								name: n.notificationName,
-							}));
 							const selectedNotifications = notificationOptions.filter((n) =>
 								(field.value ?? []).includes(n.id)
 							);
@@ -758,6 +770,110 @@ const CreateMonitorPage = () => {
 											))}
 										</Stack>
 									)}
+								</Stack>
+							);
+						}}
+					/>
+				}
+			/>
+
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalation.title")}
+				subtitle={t("pages.createMonitor.form.escalation.description")}
+				rightContent={
+					<Controller
+						name="escalation"
+						control={control}
+						render={({ field }) => {
+							const selectedEscalationChannel = notificationOptions.find(
+								(notification) => notification.id === field.value?.channelId
+							);
+							const selectedEscalationChannels = selectedEscalationChannel
+								? [selectedEscalationChannel]
+								: [];
+
+							return (
+								<Stack spacing={theme.spacing(LAYOUT.MD)}>
+									<TextField
+										type="number"
+										fieldLabel={t("pages.createMonitor.form.escalation.option.delay.label")}
+										value={field.value?.delayMinutes ?? ""}
+										onChange={(event) => {
+											const value = event.target.value;
+											if (!value) {
+												field.onChange({
+													...(field.value ?? {}),
+													delayMinutes: undefined,
+												});
+												return;
+											}
+
+											field.onChange({
+												...(field.value ?? {}),
+												delayMinutes: Number(value),
+											});
+										}}
+										fullWidth
+									/>
+
+									<Stack spacing={theme.spacing(SPACING.SM)}>
+										<Typography>
+											{t("pages.createMonitor.form.escalation.option.channels.label")}
+										</Typography>
+										<Autocomplete
+											multiple
+											options={notificationOptions}
+											value={[]}
+											getOptionLabel={(option) => option.name}
+											onChange={(_: unknown, newValue: (typeof notificationOptions)) => {
+												const selectedChannel = newValue.at(-1);
+												if (!selectedChannel) {
+													field.onChange({
+														...(field.value ?? {}),
+														channelId: "",
+													});
+													return;
+												}
+
+												field.onChange({
+													...(field.value ?? {}),
+													channelId: selectedChannel.id,
+												});
+											}}
+											isOptionEqualToValue={(option, value) => option.id === value.id}
+										/>
+
+										{selectedEscalationChannels.length > 0 && (
+											<Stack
+												flex={1}
+												width="100%"
+											>
+												{selectedEscalationChannels.map((notification, index) => (
+													<Stack
+														direction="row"
+														alignItems="center"
+														key={notification.id}
+														width="100%"
+													>
+														<Typography flexGrow={1}>{notification.notificationName}</Typography>
+														<IconButton
+															size="small"
+															onClick={() => {
+																field.onChange({
+																	...(field.value ?? {}),
+																	channelId: "",
+																});
+															}}
+															aria-label="Remove escalation notification"
+														>
+															<Trash2 size={16} />
+														</IconButton>
+														{index < selectedEscalationChannels.length - 1 && <Divider />}
+													</Stack>
+												))}
+											</Stack>
+										)}
+									</Stack>
 								</Stack>
 							);
 						}}

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -864,7 +864,7 @@ const CreateMonitorPage = () => {
 																	channelId: "",
 																});
 															}}
-															aria-label="Remove escalation notification"
+															aria-label={t("pages.createMonitor.form.escalation.option.channels.remove")}
 														>
 															<Trash2 size={16} />
 														</IconButton>

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface MonitorEscalation {
+	delayMinutes: number;
+	channelId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +65,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalation?: MonitorEscalation | null;
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -13,6 +13,16 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalation: z
+		.object({
+			delayMinutes: z
+				.number({ message: "Escalation delay is required" })
+				.min(1, "Escalation delay must be at least 1 minute")
+				.max(10080, "Escalation delay must be at most 10080 minutes"),
+			channelId: z.string().min(1, "Escalation channel is required"),
+		})
+		.nullable()
+		.optional(),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -558,7 +558,8 @@
 							"label": "Escalate after (minutes)"
 						},
 						"channels": {
-							"label": "Escalation notification channels"
+							"label": "Escalation notification channels",
+							"remove": "Remove escalation notification"
 						}
 					}
 				},

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -541,7 +541,26 @@
 				},
 				"notifications": {
 					"description": "Select the notification channels you want to use",
-					"title": "Notifications"
+					"title": "Notifications",
+					"option": {
+						"escalation": {
+							"enable": "Enable escalation",
+							"channel": "Escalation channel",
+							"delay": "Escalate after (minutes)"
+						}
+					}
+				},
+				"escalation": {
+					"title": "Escalation Rules",
+					"description": "If the monitor stays down for the specified time, notify additional channels.",
+					"option": {
+						"delay": {
+							"label": "Escalate after (minutes)"
+						},
+						"channels": {
+							"label": "Escalation notification channels"
+						}
+					}
 				},
 				"type": {
 					"description": "Select the type of check to perform",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -97,12 +97,31 @@ export const createApp = ({
 		});
 	});
 
+	app.get("/", (req, res) => {
+		res.json({
+			status: "OK",
+			message: "Checkmate API is running",
+			health: "/api/v1/health",
+			docs: "/api-docs",
+		});
+	});
+
 	// Main app routes
 	setupRoutes(app, controllers, services);
 
 	// FE routes
 	app.get("*", (req, res) => {
-		res.sendFile(path.join(frontendPath, "index.html"));
+		const indexPath = path.join(frontendPath, "index.html");
+		res.sendFile(indexPath, (error) => {
+			if (!error || res.headersSent) {
+				return;
+			}
+
+			res.status(404).json({
+				status: 404,
+				msg: "Frontend asset not found. Use /api/v1/health for backend health check.",
+			});
+		});
 	});
 	app.use(handleErrors);
 	return app;

--- a/server/src/controllers/monitorController.ts
+++ b/server/src/controllers/monitorController.ts
@@ -59,6 +59,22 @@ class MonitorController implements IMonitorController {
 		return MonitorController.SERVICE_NAME;
 	}
 
+	private validateEscalationChannel = async (teamId: string, escalation?: { channelId?: string } | null) => {
+		if (!escalation?.channelId) {
+			return;
+		}
+
+		const teamNotifications = await this.notificationsService.findNotificationsByTeamId(teamId);
+		const validNotificationIds = new Set(teamNotifications.map((notification) => notification.id));
+
+		if (!validNotificationIds.has(escalation.channelId)) {
+			throw new AppError({
+				message: `Escalation notification channel ${escalation.channelId} is invalid or does not belong to your team`,
+				status: 403,
+			});
+		}
+	};
+
 	getMonitorCertificate = async (req: Request, res: Response, next: NextFunction) => {
 		try {
 			const validatedParams = getCertificateParamValidation.parse(req.params);
@@ -205,6 +221,7 @@ class MonitorController implements IMonitorController {
 
 			const userId = requireUserId(req.user?.id);
 			const teamId = requireTeamId(req.user?.teamId);
+			await this.validateEscalationChannel(teamId, validatedBody.escalation);
 
 			const monitor = await this.monitorService.createMonitor(teamId, userId, validatedBody);
 
@@ -275,6 +292,7 @@ class MonitorController implements IMonitorController {
 			const validatedBody = editMonitorBodyValidation.parse(req.body);
 			const monitorId = validatedParams.monitorId;
 			const teamId = requireTeamId(req.user?.teamId);
+			await this.validateEscalationChannel(teamId, validatedBody.escalation);
 
 			const editedMonitor = await this.monitorService.editMonitor({ teamId, monitorId, body: validatedBody });
 

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -1,5 +1,5 @@
 import { Schema, model, Types } from "mongoose";
-import type { Monitor, MonitorMatchMethod, CheckSnapshot } from "@/types/monitor.js";
+import type { Monitor, MonitorEscalation, MonitorMatchMethod, CheckSnapshot } from "@/types/monitor.js";
 import { MonitorTypes, MonitorStatuses } from "@/types/monitor.js";
 import type {
 	CheckAudits,
@@ -18,11 +18,15 @@ type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Dat
 
 type MonitorDocumentBase = Omit<
 	Monitor,
-	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
+	"id" | "userId" | "teamId" | "notifications" | "escalation" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
 > & {
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
+	escalation?: {
+		delayMinutes: number;
+		channelId: Types.ObjectId;
+	} | null;
 	selectedDisks: string[];
 	matchMethod?: MonitorMatchMethod;
 };
@@ -198,6 +202,22 @@ const checkSnapshotSchema = new Schema<CheckSnapshotDocument>(
 	{ _id: false }
 );
 
+const escalationSchema = new Schema<MonitorEscalation>(
+	{
+		delayMinutes: {
+			type: Number,
+			min: 1,
+			required: true,
+		},
+		channelId: {
+			type: Schema.Types.ObjectId,
+			ref: "Notification",
+			required: true,
+		},
+	},
+	{ _id: false }
+);
+
 const MonitorSchema = new Schema<MonitorDocument>(
 	{
 		userId: {
@@ -284,6 +304,10 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalation: {
+			type: escalationSchema,
+			default: null,
+		},
 		secret: {
 			type: String,
 		},

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -351,6 +351,12 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification) => toStringId(notification));
+		const escalation = doc.escalation
+			? {
+				delayMinutes: doc.escalation.delayMinutes,
+				channelId: toStringId(doc.escalation.channelId),
+			}
+			: null;
 
 		return {
 			id: toStringId(doc._id),
@@ -374,6 +380,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalation,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -410,6 +417,12 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification: unknown) => toStringId(notification));
+		const escalation = doc.escalation
+			? {
+				delayMinutes: doc.escalation.delayMinutes,
+				channelId: toStringId(doc.escalation.channelId),
+			}
+			: null;
 
 		return {
 			id: toStringId(doc._id),
@@ -433,6 +446,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalation,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/business/monitorService.ts
+++ b/server/src/service/business/monitorService.ts
@@ -165,8 +165,30 @@ export class MonitorService implements IMonitorService {
 		return formatLookup[dateRange];
 	};
 
+	private normalizeEscalation = (escalation?: Monitor["escalation"]): Monitor["escalation"] => {
+		if (!escalation) {
+			return null;
+		}
+
+		if (!escalation.channelId || !Number.isFinite(escalation.delayMinutes) || escalation.delayMinutes <= 0) {
+			return null;
+		}
+
+		return {
+			channelId: escalation.channelId,
+			delayMinutes: Math.floor(escalation.delayMinutes),
+		};
+	};
+
 	createMonitor = async (teamId: string, userId: string, body: Monitor): Promise<void> => {
-		const monitor = await this.monitorsRepository.create(body, teamId, userId);
+		const monitor = await this.monitorsRepository.create(
+			{
+				...body,
+				escalation: this.normalizeEscalation(body.escalation),
+			},
+			teamId,
+			userId
+		);
 		if (!monitor) {
 			throw new AppError({ message: "Failed to create monitor", status: 500, service: SERVICE_NAME, method: "createMonitor" });
 		}
@@ -437,7 +459,10 @@ export class MonitorService implements IMonitorService {
 	};
 
 	editMonitor = async ({ teamId, monitorId, body }: { teamId: string; monitorId: string; body: Partial<Monitor> }) => {
-		const editedMonitor = await this.monitorsRepository.updateById(monitorId, teamId, body);
+		const editedMonitor = await this.monitorsRepository.updateById(monitorId, teamId, {
+			...body,
+			escalation: this.normalizeEscalation(body.escalation),
+		});
 		await this.jobQueue.updateJob(editedMonitor);
 		return editedMonitor;
 	};

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -23,6 +23,7 @@ import {
 } from "@/repositories/index.js";
 import { ILogger } from "@/utils/logger.js";
 import { IBufferService } from "@/service/index.js";
+import type { MonitorStatusResponse } from "@/types/network.js";
 
 export interface ISuperSimpleQueueHelper {
 	readonly serviceName: string;
@@ -38,7 +39,7 @@ export interface MonitorActionDecision {
 	shouldResolveIncident: boolean;
 	shouldSendNotification: boolean;
 	incidentReason: "status_down" | "threshold_breach" | null;
-	notificationReason: "status_change" | "threshold_breach" | null;
+	notificationReason: "status_change" | "threshold_breach" | "escalation" | null;
 	thresholdBreaches?: {
 		cpu?: boolean;
 		memory?: boolean;
@@ -66,6 +67,7 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 	private incidentsRepository: IIncidentsRepository;
 	private geoChecksService: IGeoChecksService;
 	private geoChecksRepository: IGeoChecksRepository;
+	private escalationTimers: Map<string, NodeJS.Timeout>;
 
 	constructor(
 		logger: ILogger,
@@ -101,6 +103,7 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 		this.incidentsRepository = incidentsRepository;
 		this.geoChecksService = geoChecksService;
 		this.geoChecksRepository = geoChecksRepository;
+		this.escalationTimers = new Map<string, NodeJS.Timeout>();
 	}
 
 	get serviceName() {
@@ -120,6 +123,7 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 
 				const maintenanceWindowActive = await this.isInMaintenanceWindow(monitorId, teamId);
 				if (maintenanceWindowActive) {
+					this.clearEscalationTimer(monitorId);
 					this.logger.debug({
 						message: `Monitor ${monitorId} is in maintenance window`,
 						service: SERVICE_NAME,
@@ -156,6 +160,14 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 				// Step 5.  Get decisions
 				const decision = this.evaluateMonitorAction(statusChangeResult);
 
+				if (decision.shouldCreateIncident) {
+					this.scheduleEscalation(statusChangeResult.monitor);
+				}
+
+				if (decision.shouldResolveIncident) {
+					this.clearEscalationTimer(statusChangeResult.monitor.id);
+				}
+
 				// Step 6. Handle notifications (best effort, continue even in event of failure, don't wait)
 				if (decision.shouldSendNotification) {
 					this.notificationsService.handleNotifications(statusChangeResult.monitor, status, decision).catch((error: unknown) => {
@@ -187,6 +199,92 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 				throw error;
 			}
 		};
+	};
+
+	private scheduleEscalation = (monitor: Monitor) => {
+		const escalation = monitor.escalation;
+		if (!escalation?.channelId || !Number.isFinite(escalation.delayMinutes) || escalation.delayMinutes <= 0) {
+			return;
+		}
+
+		this.clearEscalationTimer(monitor.id);
+
+		const delayMs = escalation.delayMinutes * 60 * 1000;
+		const timer = setTimeout(() => {
+			void this.triggerEscalation(monitor.id, monitor.teamId, escalation.channelId);
+		}, delayMs);
+
+		this.escalationTimers.set(monitor.id, timer);
+		this.logger.debug({
+			message: `Scheduled escalation for monitor ${monitor.id} in ${escalation.delayMinutes} minute(s)`,
+			service: SERVICE_NAME,
+			method: "scheduleEscalation",
+		});
+	};
+
+	private clearEscalationTimer = (monitorId: string) => {
+		const timer = this.escalationTimers.get(monitorId);
+		if (!timer) {
+			return;
+		}
+
+		clearTimeout(timer);
+		this.escalationTimers.delete(monitorId);
+	};
+
+	private triggerEscalation = async (monitorId: string, teamId: string, scheduledChannelId: string) => {
+		this.escalationTimers.delete(monitorId);
+
+		try {
+			const monitor = await this.monitorsRepository.findById(monitorId, teamId);
+			const escalation = monitor.escalation;
+
+			if (!escalation?.channelId || escalation.channelId !== scheduledChannelId) {
+				return;
+			}
+
+			const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitorId, teamId);
+			if (!activeIncident) {
+				return;
+			}
+
+			const escalationDecision: MonitorActionDecision = {
+				shouldCreateIncident: false,
+				shouldResolveIncident: false,
+				shouldSendNotification: true,
+				incidentReason: null,
+				notificationReason: "escalation",
+			};
+
+			const escalationStatus: MonitorStatusResponse = {
+				monitorId,
+				teamId,
+				type: monitor.type,
+				status: false,
+				code: activeIncident.statusCode ?? 500,
+				message: activeIncident.message || "Escalation triggered",
+			};
+
+			const escalationMonitor: Monitor = {
+				...monitor,
+				notifications: [escalation.channelId],
+			};
+
+			await this.notificationsService.handleNotifications(escalationMonitor, escalationStatus, escalationDecision);
+
+			this.logger.info({
+				message: `Escalation notification sent for monitor ${monitorId}`,
+				service: SERVICE_NAME,
+				method: "triggerEscalation",
+			});
+		} catch (error: unknown) {
+			this.logger.error({
+				message: `Failed escalation for monitor ${monitorId}: ${error instanceof Error ? error.message : "Unknown error"}`,
+				service: SERVICE_NAME,
+				method: "triggerEscalation",
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+		}
 	};
 
 	getCleanupOrphanedJob = () => {

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -31,7 +31,7 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	): NotificationMessage {
 		const type = this.determineNotificationType(decision, monitor);
 		const severity = this.determineSeverity(type);
-		const content = this.buildContent(type, monitor, monitorStatusResponse);
+		const content = this.applyEscalationContent(this.buildContent(type, monitor, monitorStatusResponse), decision, monitor);
 
 		return {
 			type,
@@ -49,6 +49,18 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 				teamId: monitor.teamId,
 				notificationReason: decision.notificationReason || "status_change",
 			},
+		};
+	}
+
+	private applyEscalationContent(content: NotificationContent, decision: MonitorActionDecision, monitor: Monitor): NotificationContent {
+		if (decision.notificationReason !== "escalation" || monitor.status !== "down") {
+			return content;
+		}
+
+		return {
+			...content,
+			title: `Escalation: Monitor ${monitor.name} is still down`,
+			summary: `Escalation: Monitor "${monitor.name}" is still down.`,
 		};
 	}
 

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -80,6 +80,9 @@ export class EmailProvider implements INotificationProvider {
 	private buildSubject(message: NotificationMessage): string {
 		switch (message.type) {
 			case "monitor_down":
+				if (message.metadata.notificationReason === "escalation") {
+					return `Escalation: Monitor ${message.monitor.name} is still down`;
+				}
 				return `Monitor ${message.monitor.name} is down`;
 			case "monitor_up":
 				return `Monitor ${message.monitor.name} is back up`;

--- a/server/src/service/infrastructure/statusService.ts
+++ b/server/src/service/infrastructure/statusService.ts
@@ -42,6 +42,8 @@ export interface IStatusService {
 
 export class StatusService implements IStatusService {
 	static SERVICE_NAME = SERVICE_NAME;
+	private static readonly OBJECT_ID_REGEX = /^[a-fA-F0-9]{24}$/;
+	private static readonly OBJECT_ID_EMBEDDED_REGEX = /[a-fA-F0-9]{24}/;
 	private logger: ILogger;
 	private buffer: IBufferService;
 	private monitorsRepository: IMonitorsRepository;
@@ -64,6 +66,33 @@ export class StatusService implements IStatusService {
 
 	get serviceName() {
 		return StatusService.SERVICE_NAME;
+	}
+
+	private normalizeNotificationIds(notificationIds: string[] = []): string[] {
+		const normalized = new Set<string>();
+
+		for (const rawNotificationId of notificationIds) {
+			if (typeof rawNotificationId !== "string") {
+				continue;
+			}
+
+			const trimmed = rawNotificationId.trim();
+			if (!trimmed) {
+				continue;
+			}
+
+			if (StatusService.OBJECT_ID_REGEX.test(trimmed)) {
+				normalized.add(trimmed);
+				continue;
+			}
+
+			const embeddedObjectIdMatch = trimmed.match(StatusService.OBJECT_ID_EMBEDDED_REGEX);
+			if (embeddedObjectIdMatch?.[0]) {
+				normalized.add(embeddedObjectIdMatch[0]);
+			}
+		}
+
+		return [...normalized];
 	}
 
 	async updateRunningStats(monitor: Monitor, networkResponse: MonitorStatusResponse) {
@@ -194,6 +223,7 @@ export class StatusService implements IStatusService {
 		try {
 			const { monitorId, teamId, status, code } = statusResponse;
 			const monitor = await this.monitorsRepository.findById(monitorId, teamId);
+			monitor.notifications = this.normalizeNotificationIds(monitor.notifications);
 
 			// Update running stats
 			this.updateRunningStats(monitor, statusResponse);

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface MonitorEscalation {
+	delayMinutes: number;
+	channelId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +42,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalation?: MonitorEscalation | null;
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -3,6 +3,11 @@ import { booleanCoercion } from "./shared.js";
 import { GeoContinents } from "@/types/geoCheck.js";
 import { MonitorMatchMethods, MonitorTypes } from "@/types/monitor.js";
 
+const escalationValidation = z.object({
+	delayMinutes: z.number().min(1).max(10080),
+	channelId: z.string().min(1, "Escalation channel ID is required"),
+});
+
 export const getMonitorByIdParamValidation = z.object({
 	monitorId: z.string().min(1, "Monitor ID is required"),
 });
@@ -67,6 +72,7 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalation: escalationValidation.nullable().optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +95,7 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalation: escalationValidation.nullable().optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),
@@ -144,6 +151,7 @@ const importedMonitorSchema = z.object({
 	interval: z.number().default(60000),
 	uptimePercentage: z.number().optional(),
 	notifications: z.array(z.string()).default([]),
+	escalation: escalationValidation.nullable().default(null),
 	secret: z.string().optional(),
 	cpuAlertThreshold: z.number().default(100),
 	cpuAlertCounter: z.number().default(5),


### PR DESCRIPTION
## Describe your changes

Added ability to select notification channel and escalation time for escalation notifications. These escalation notifications are sent out to the designated notification channel after the designated escalation time if the monitor has been down after that period of time.

## Write your issue number after "Fixes "

Fixes #1

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x ] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x ] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x ] I have included the issue # in the PR.
- [x ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x ] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x ] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x ] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x ] My PR is granular and targeted to one specific feature.
- [x ] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x ] I took a screenshot or a video and attached to this PR if there is a UI change.

<img width="1514" height="448" alt="Screenshot 2026-04-05 181523" src="https://github.com/user-attachments/assets/ddae7067-5758-4720-98cd-2deda9bdeebe" />

