### PR TITLE
Escalation feature implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 .idea
 .vscode
 .VSCodeCounter

--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalations: data?.escalations || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -2,12 +2,13 @@ import { useMemo, useState } from "react";
 import { useEffect } from "react";
 import { logger } from "@/Utils/logger";
 import { useParams, useLocation, useNavigate } from "react-router";
-import { useForm, Controller } from "react-hook-form";
+import { useForm, Controller, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTheme } from "@mui/material";
 import Stack from "@mui/material/Stack";
 import RadioGroup from "@mui/material/RadioGroup";
 import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
 import { Trans, useTranslation } from "react-i18next";
 import MenuItem from "@mui/material/MenuItem";
 import Typography from "@mui/material/Typography";
@@ -203,6 +204,7 @@ const CreateMonitorPage = () => {
 		defaultValues: defaults,
 	});
 	const { control, watch, handleSubmit, clearErrors } = form;
+	const { fields: escalationFields, append, remove } = useFieldArray({ control, name: "escalations" as const });
 
 	useEffect(() => {
 		form.reset(defaults);
@@ -433,7 +435,7 @@ const CreateMonitorPage = () => {
 												</MenuItem>
 											))}
 									</Select>
-								)}
+					)}
 							/>
 						)}
 
@@ -569,7 +571,7 @@ const CreateMonitorPage = () => {
 									)}
 								</MenuItem>
 							</Select>
-						)}
+					)}
 					/>
 				}
 			/>
@@ -764,6 +766,88 @@ const CreateMonitorPage = () => {
 					/>
 				}
 			/>
+		<ConfigBox
+			title="Escalation Rules"
+			subtitle="Send follow-up alerts to a different notification channel if the incident remains unresolved."
+			rightContent={
+				<Stack spacing={theme.spacing(LAYOUT.MD)}>
+					{escalationFields.map((field, index) => (
+						<Stack
+							key={field.id}
+							direction="column"
+							spacing={theme.spacing(LAYOUT.SM)}
+							sx={{
+								border: `1px solid ${theme.palette.divider}`,
+								borderRadius: 1,
+								p: theme.spacing(2),
+								backgroundColor: theme.palette.mode === "dark" ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.02)",
+							}}
+						>
+							<Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2}>
+								<Stack direction="row" spacing={2} sx={{ flex: 1 }}>
+									<Controller
+										name={`escalations.${index}.delayMinutes` as const}
+										control={control}
+										render={({ field }) => (
+											<TextField
+												label="Delay (minutes)"
+												type="number"
+												value={field.value}
+												onChange={(event) => field.onChange(Number(event.target.value))}
+												inputProps={{ min: 1 }}
+												size="small"
+												sx={{ width: 140 }}
+											/>
+										)}
+									/>
+									<Controller
+										name={`escalations.${index}.channelId` as const}
+										control={control}
+										render={({ field }) => (
+											<TextField
+												select
+												label="Notification channel"
+												value={field.value ?? ""}
+												onChange={(event) => field.onChange(event.target.value)}
+												size="small"
+												fullWidth
+											>
+												<MenuItem value="">-- Select channel --</MenuItem>
+												{(notifications ?? []).map((notification) => (
+													<MenuItem key={notification.id} value={notification.id}>
+														{notification.notificationName}
+													</MenuItem>
+												))}
+											</TextField>
+										)}
+									/>
+								</Stack>
+								<IconButton
+									onClick={() => remove(index)}
+									aria-label="Remove escalation"
+									size="small"
+									color="error"
+								>
+									<Trash2 size={16} />
+								</IconButton>
+							</Stack>
+						</Stack>
+					))}
+					<Button
+						variant="outlined"
+						onClick={() => append({ delayMinutes: 1, channelId: "" })}
+					>
+						Add escalation rule
+					</Button>
+					{escalationFields.length === 0 && (
+						<Typography color="text.secondary">
+							No escalation rules configured.
+						</Typography>
+					)}
+				</Stack>
+			}
+		/>
+
 
 			{(watchedType === "http" ||
 				watchedType === "grpc" ||

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface NotificationEscalationRule {
+	delayMinutes: number;
+	channelId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +65,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalations: NotificationEscalationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -13,6 +13,12 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalations: z.array(
+		z.object({
+			delayMinutes: z.number().min(0, "Delay must be at least 0 minutes"),
+			channelId: z.string().min(1, "Notification channel is required"),
+		})
+	),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -72,6 +72,10 @@ const IncidentSchema = new Schema<IncidentDocument>(
 			type: String,
 			default: null,
 		},
+		escalationChannelIdsSent: {
+			type: [String],
+			default: [],
+		},
 	},
 	{ timestamps: true }
 );

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -23,6 +23,7 @@ type MonitorDocumentBase = Omit<
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
+	escalations: Array<{ delayMinutes: number; channelId: Types.ObjectId }>;
 	selectedDisks: string[];
 	matchMethod?: MonitorMatchMethod;
 };
@@ -284,6 +285,22 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalations: {
+			type: [
+				{
+					delayMinutes: {
+						type: Number,
+						default: 0,
+						min: 0,
+					},
+					channelId: {
+						type: Schema.Types.ObjectId,
+						ref: "Notification",
+					},
+				},
+			],
+			default: [],
+		},
 		secret: {
 			type: String,
 		},

--- a/server/src/repositories/incidents/MongoIncidentRepository.ts
+++ b/server/src/repositories/incidents/MongoIncidentRepository.ts
@@ -57,6 +57,7 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			message: doc.message ?? null,
 			statusCode: doc.statusCode ?? null,
 			resolutionType: doc.resolutionType ?? null,
+			escalationChannelIdsSent: doc.escalationChannelIdsSent ?? [],
 			resolvedBy: doc.resolvedBy ? this.toStringId(doc.resolvedBy) : null,
 			resolvedByEmail: doc.resolvedByEmail ?? null,
 			comment: doc.comment ?? null,

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -374,6 +374,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalations: (doc.escalations ?? []).map((escalation) => ({
+				delayMinutes: escalation.delayMinutes,
+				channelId: toStringId(escalation.channelId),
+			})),
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -433,6 +437,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalations: (doc.escalations ?? []).map((escalation) => ({
+				delayMinutes: escalation.delayMinutes,
+				channelId: toStringId(escalation.channelId),
+			})),
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -39,6 +39,7 @@ export interface MonitorActionDecision {
 	shouldSendNotification: boolean;
 	incidentReason: "status_down" | "threshold_breach" | null;
 	notificationReason: "status_change" | "threshold_breach" | null;
+	isEscalation?: boolean;
 	thresholdBreaches?: {
 		cpu?: boolean;
 		memory?: boolean;
@@ -169,7 +170,13 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 				}
 
 				// Step 7. Handle incidents (best effort, don't wait)
-				this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status).catch((error: unknown) => {
+				this.incidentService
+				.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status)
+				.then(async () => {
+					const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitorId, teamId);
+					await this.processEscalations(statusChangeResult.monitor, status, activeIncident, decision);
+				})
+				.catch((error: unknown) => {
 					this.logger.warn({
 						message: `Error handling incident for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
 						service: SERVICE_NAME,
@@ -417,6 +424,69 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 			}
 		};
 	};
+
+	private async processEscalations(
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		activeIncident: { id: string; teamId: string; startTime: string; escalationChannelIdsSent?: string[] } | null,
+		decision: MonitorActionDecision
+	) {
+		if (!activeIncident || monitor.status === "up" || monitor.status === "paused" || monitor.status === "maintenance") {
+			return;
+		}
+
+		const escalationRules = monitor.escalations ?? [];
+		if (escalationRules.length === 0) {
+			return;
+		}
+
+		const incidentStart = new Date(activeIncident.startTime).getTime();
+		if (Number.isNaN(incidentStart)) {
+			return;
+		}
+
+		const elapsedMs = Date.now() - incidentStart;
+		const sentChannels = new Set(activeIncident.escalationChannelIdsSent ?? []);
+		const escalationDecision: MonitorActionDecision = {
+			shouldCreateIncident: false,
+			shouldResolveIncident: false,
+			shouldSendNotification: true,
+			incidentReason: monitor.status === "breached" ? "threshold_breach" : "status_down",
+			notificationReason: monitor.status === "breached" ? "threshold_breach" : "status_change",
+			isEscalation: true,
+		};
+
+		for (const rule of escalationRules.sort((a, b) => a.delayMinutes - b.delayMinutes)) {
+			if (!rule.channelId || rule.delayMinutes < 0 || sentChannels.has(rule.channelId)) {
+				continue;
+			}
+
+			const delayMs = rule.delayMinutes * 60 * 1000;
+			if (elapsedMs < delayMs) {
+				continue;
+			}
+
+			const sent = await this.notificationsService.sendNotifications(
+				monitor,
+				monitorStatusResponse,
+				escalationDecision,
+				[rule.channelId]
+			);
+
+			if (sent) {
+				sentChannels.add(rule.channelId);
+				await this.incidentsRepository.updateById(activeIncident.id, activeIncident.teamId, {
+					escalationChannelIdsSent: Array.from(sentChannels),
+				});
+			} else {
+				this.logger.warn({
+					message: `Failed to send escalation notification for monitor ${monitor.id} on channel ${rule.channelId}`,
+					service: SERVICE_NAME,
+					method: "processEscalations",
+				});
+			}
+		}
+	}
 
 	private evaluateMonitorAction(statusChangeResult: StatusChangeResult): MonitorActionDecision {
 		const { monitor, statusChanged, prevStatus } = statusChangeResult;

--- a/server/src/service/infrastructure/network/HttpProvider.ts
+++ b/server/src/service/infrastructure/network/HttpProvider.ts
@@ -3,10 +3,11 @@ import { IAdvancedMatcher } from "@/service/infrastructure/network/AdvancedMatch
 import { IStatusProvider } from "@/service/infrastructure/network/IStatusProvider.js";
 import { HttpStatusPayload } from "@/types/network.js";
 import { MonitorStatusResponse } from "@/types/network.js";
+import { Agent as HttpAgent } from "http";
 import { Agent as HttpsAgent } from "https";
+import { lookup } from "dns";
 import { Monitor, MonitorType } from "@/types/monitor.js";
 import { NETWORK_ERROR } from "@/service/infrastructure/network/utils.js";
-import CacheableLookup from "cacheable-lookup";
 
 export class HttpProvider implements IStatusProvider<HttpStatusPayload> {
 	readonly type = "http";
@@ -15,9 +16,7 @@ export class HttpProvider implements IStatusProvider<HttpStatusPayload> {
 		private got: Got,
 		private advancedMatcher: IAdvancedMatcher
 	) {
-		const cacheable = new CacheableLookup({ maxTtl: 300, errorTtl: 30 });
 		this.got = got.extend({
-			dnsCache: cacheable,
 			timeout: {
 				request: 30000,
 			},
@@ -68,7 +67,8 @@ export class HttpProvider implements IStatusProvider<HttpStatusPayload> {
 		};
 
 		options.agent = {
-			https: new HttpsAgent({ rejectUnauthorized: !ignoreTlsErrors }),
+			http: new HttpAgent({ lookup }),
+			https: new HttpsAgent({ rejectUnauthorized: !ignoreTlsErrors, lookup }),
 		};
 
 		try {

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -31,7 +31,7 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	): NotificationMessage {
 		const type = this.determineNotificationType(decision, monitor);
 		const severity = this.determineSeverity(type);
-		const content = this.buildContent(type, monitor, monitorStatusResponse);
+		const content = this.buildContent(type, monitor, monitorStatusResponse, decision.isEscalation ?? false);
 
 		return {
 			type,
@@ -48,6 +48,7 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 			metadata: {
 				teamId: monitor.teamId,
 				notificationReason: decision.notificationReason || "status_change",
+				isEscalation: decision.isEscalation ?? false,
 			},
 		};
 	}
@@ -93,14 +94,14 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		}
 	}
 
-	private buildContent(type: NotificationType, monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): NotificationContent {
+	private buildContent(type: NotificationType, monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, isEscalation: boolean): NotificationContent {
 		switch (type) {
 			case "monitor_down":
-				return this.buildMonitorDownContent(monitor, monitorStatusResponse);
+				return this.buildMonitorDownContent(monitor, monitorStatusResponse, isEscalation);
 			case "monitor_up":
 				return this.buildMonitorUpContent(monitor);
 			case "threshold_breach":
-				return this.buildThresholdBreachContent(monitor, monitorStatusResponse as MonitorStatusResponse<HardwareStatusPayload>);
+				return this.buildThresholdBreachContent(monitor, monitorStatusResponse as MonitorStatusResponse<HardwareStatusPayload>, isEscalation);
 			case "threshold_resolved":
 				return this.buildThresholdResolvedContent(monitor);
 			default:
@@ -108,9 +109,10 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		}
 	}
 
-	private buildMonitorDownContent(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): NotificationContent {
-		const title = `Monitor Down: ${monitor.name}`;
-		const summary = `Monitor "${monitor.name}" is currently down and unreachable.`;
+	private buildMonitorDownContent(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, isEscalation: boolean = false): NotificationContent {
+		const prefix = isEscalation ? "Escalation - " : "";
+		const title = `${prefix}Monitor Down: ${monitor.name}`;
+		const summary = `${isEscalation ? "[Escalation] " : ""}Monitor "${monitor.name}" is currently down and unreachable.`;
 		const details = [`URL: ${monitor.url}`, `Status: Down`, `Type: ${monitor.type}`];
 
 		// Add response code if available
@@ -144,9 +146,10 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		};
 	}
 
-	private buildThresholdBreachContent(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse<HardwareStatusPayload>): NotificationContent {
-		const title = `Threshold Exceeded: ${monitor.name}`;
-		const summary = `Monitor "${monitor.name}" has exceeded one or more thresholds.`;
+	private buildThresholdBreachContent(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse<HardwareStatusPayload>, isEscalation: boolean = false): NotificationContent {
+		const prefix = isEscalation ? "Escalation - " : "";
+		const title = `${prefix}Threshold Exceeded: ${monitor.name}`;
+		const summary = `${isEscalation ? "[Escalation] " : ""}Monitor "${monitor.name}" has exceeded one or more thresholds.`;
 		const details = [`URL: ${monitor.url}`, `Status: Threshold exceeded`, `Type: ${monitor.type}`];
 
 		const thresholds = this.extractThresholdBreaches(monitor, monitorStatusResponse);

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -78,17 +78,18 @@ export class EmailProvider implements INotificationProvider {
 	}
 
 	private buildSubject(message: NotificationMessage): string {
+		const prefix = message.metadata.isEscalation ? "[Escalation] " : "";
 		switch (message.type) {
 			case "monitor_down":
-				return `Monitor ${message.monitor.name} is down`;
+				return `${prefix}Monitor ${message.monitor.name} is down`;
 			case "monitor_up":
-				return `Monitor ${message.monitor.name} is back up`;
+				return `${prefix}Monitor ${message.monitor.name} is back up`;
 			case "threshold_breach":
-				return `Monitor ${message.monitor.name} threshold exceeded`;
+				return `${prefix}Monitor ${message.monitor.name} threshold exceeded`;
 			case "threshold_resolved":
-				return `Monitor ${message.monitor.name} thresholds resolved`;
+				return `${prefix}Monitor ${message.monitor.name} thresholds resolved`;
 			default:
-				return `Alert: ${message.monitor.name}`;
+				return `${prefix}Alert: ${message.monitor.name}`;
 		}
 	}
 

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,6 +14,7 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	sendNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision, notificationIds: string[]) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -107,14 +108,22 @@ export class NotificationsService implements INotificationsService {
 		}
 	};
 
-	private sendNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
-		const notificationIds = monitor.notifications ?? [];
+	private buildNotificationMessage = (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+		return this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, decision, clientHost);
+	};
+
+	sendNotifications = async (
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		decision: MonitorActionDecision,
+		notificationIds: string[]
+	) => {
 		const notifications = await this.notificationsRepository.findNotificationsByIds(notificationIds);
 
 		// Build notification message once for all notifications
-		const settings = this.settingsService.getSettings();
-		const clientHost = settings.clientHost || "Host not defined";
-		const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, decision, clientHost);
+		const notificationMessage = this.buildNotificationMessage(monitor, monitorStatusResponse, decision);
 
 		const tasks = notifications.map((notification) => this.send(notification, monitor, monitorStatusResponse, decision, notificationMessage));
 
@@ -138,7 +147,8 @@ export class NotificationsService implements INotificationsService {
 		}
 
 		// Send notifications based on decision
-		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+		const notificationIds = monitor.notifications ?? [];
+		return await this.sendNotifications(monitor, monitorStatusResponse, decision, notificationIds);
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -13,6 +13,7 @@ export interface Incident {
 	message?: string | null;
 	statusCode?: number | null;
 	resolutionType: IncidentResolutionType;
+	escalationChannelIdsSent?: string[];
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;
 	comment?: string | null;

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface NotificationEscalationRule {
+	delayMinutes: number;
+	channelId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +42,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalations: NotificationEscalationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/types/notificationMessage.ts
+++ b/server/src/types/notificationMessage.ts
@@ -49,5 +49,6 @@ export interface NotificationMessage {
 	metadata: {
 		teamId: string;
 		notificationReason: string;
+		isEscalation?: boolean;
 	};
 }

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -67,6 +67,12 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalations: z.array(
+		z.object({
+			delayMinutes: z.number().min(0).default(0),
+			channelId: z.string().min(1, "Notification channel is required"),
+		})
+	).optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +95,12 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalations: z.array(
+		z.object({
+			delayMinutes: z.number().min(0).default(0),
+			channelId: z.string().min(1, "Notification channel is required"),
+		})
+	).optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),
@@ -144,6 +156,12 @@ const importedMonitorSchema = z.object({
 	interval: z.number().default(60000),
 	uptimePercentage: z.number().optional(),
 	notifications: z.array(z.string()).default([]),
+	escalations: z.array(
+		z.object({
+			delayMinutes: z.number().min(0).default(0),
+			channelId: z.string().min(1, "Notification channel is required"),
+		})
+	).default([]),
 	secret: z.string().optional(),
 	cpuAlertThreshold: z.number().default(100),
 	cpuAlertCounter: z.number().default(5),


### PR DESCRIPTION
## Describe your changes

Added escalation notification feature for monitors. When a monitor remains down beyond a configured delay, a follow-up alert is sent to a designated escalation notification channel. Escalation emails are clearly labeled with [Escalation] in the subject line. Also fixed sendNotifications not being exposed on the INotificationsService interface, and corrected broken .gitignore patterns in the server folder.

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x ] (Do not skip this or your PR will be closed) I deployed the application locally.
- [ x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [ x] I have included the issue # in the PR.
- [ x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [ x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [ x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [ x] My PR is granular and targeted to one specific feature.
- [ x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ x] I took a screenshot or a video and attached to this PR if there is a UI change.

<img width="2042" height="236" alt="image" src="https://github.com/user-attachments/assets/db36872f-9b63-4e52-ba33-dddf6b502cbf" />


