### PR TITLE
Escalation email pr

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalations: data?.escalations || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -14,7 +14,7 @@ import Typography from "@mui/material/Typography";
 import Link from "@mui/material/Link";
 import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
-import { Trash2 } from "lucide-react";
+import { Trash2, Plus } from "lucide-react";
 import { HeaderDeleteControls } from "@/Components/monitors";
 import { GeoContinents } from "@/Types/GeoCheck";
 
@@ -39,6 +39,7 @@ import {
 	supportsGeoCheck,
 } from "@/Types/Monitor";
 import type { Notification } from "@/Types/Notification";
+import type { EscalationRule } from "@/Types/Monitor";
 import type { MonitorFormData } from "@/Validation/monitor";
 
 interface GeneralSettingsConfig {
@@ -758,6 +759,129 @@ const CreateMonitorPage = () => {
 											))}
 										</Stack>
 									)}
+								</Stack>
+							);
+						}}
+					/>
+				}
+			/>
+
+			<ConfigBox
+				title="Escalation Rules"
+				subtitle="Configure delayed notifications that fire if an incident remains unresolved after a specified time."
+				rightContent={
+					<Controller
+						name="escalations"
+						control={control}
+						render={({ field }) => {
+							const escalations: EscalationRule[] = field.value ?? [];
+							const notificationOptions = (notifications ?? []).map(
+								(n) => ({
+									...n,
+									name: n.notificationName,
+								})
+							);
+
+							const addEscalation = () => {
+								field.onChange([
+									...escalations,
+									{ notificationId: "", delayMinutes: 5 },
+								]);
+							};
+
+							const removeEscalation = (index: number) => {
+								field.onChange(
+									escalations.filter((_, i) => i !== index)
+								);
+							};
+
+							const updateEscalation = (
+								index: number,
+								updates: Partial<EscalationRule>
+							) => {
+								const updated = escalations.map((esc, i) =>
+									i === index ? { ...esc, ...updates } : esc
+								);
+								field.onChange(updated);
+							};
+
+							return (
+								<Stack spacing={theme.spacing(LAYOUT.MD)}>
+									{escalations.map((esc, index) => (
+										<Stack
+											key={index}
+											direction="row"
+											spacing={theme.spacing(LAYOUT.SM)}
+											alignItems="center"
+										>
+											<Select
+												value={esc.notificationId}
+												onChange={(e) =>
+													updateEscalation(index, {
+														notificationId:
+															e.target.value as string,
+													})
+												}
+												fieldLabel={
+													index === 0
+														? "Channel"
+														: undefined
+												}
+												sx={{ flex: 2 }}
+											>
+												<MenuItem value="">
+													Select channel...
+												</MenuItem>
+												{notificationOptions.map((n) => (
+													<MenuItem
+														key={n.id}
+														value={n.id}
+													>
+														{n.notificationName} (
+														{n.type})
+													</MenuItem>
+												))}
+											</Select>
+											<TextField
+												type="number"
+												value={esc.delayMinutes}
+												onChange={(e) =>
+													updateEscalation(index, {
+														delayMinutes:
+															Number(
+																e.target.value
+															) || 1,
+													})
+												}
+												fieldLabel={
+													index === 0
+														? "Delay (min)"
+														: undefined
+												}
+												sx={{ flex: 1, minWidth: 100 }}
+											/>
+											<IconButton
+												size="small"
+												onClick={() =>
+													removeEscalation(index)
+												}
+												aria-label="Remove escalation"
+												sx={{
+													mt: index === 0 ? "20px" : 0,
+												}}
+											>
+												<Trash2 size={16} />
+											</IconButton>
+										</Stack>
+									))}
+									<Button
+										variant="outlined"
+										onClick={addEscalation}
+										startIcon={<Plus size={16} />}
+										sx={{ alignSelf: "flex-start" }}
+									>
+										Add escalation
+									</Button>
 								</Stack>
 							);
 						}}

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface EscalationRule {
+	notificationId: string;
+	delayMinutes: number;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +65,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalations: EscalationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -4,7 +4,14 @@ import { GeoContinents } from "@/Types/GeoCheck";
 // URL schema with custom error message
 const urlSchema = z.url({ message: "Please enter a valid URL" });
 
-// Common base schema for all monitor types
+const escalationRuleSchema = z.object({
+	notificationId: z.string().min(1, "Notification channel is required"),
+	delayMinutes: z
+		.number()
+		.min(1, "Delay must be at least 1 minute")
+		.max(1440, "Delay cannot exceed 24 hours"),
+});
+
 const baseSchema = z.object({
 	name: z
 		.string()
@@ -13,6 +20,7 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalations: z.array(escalationRuleSchema),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -72,6 +72,10 @@ const IncidentSchema = new Schema<IncidentDocument>(
 			type: String,
 			default: null,
 		},
+		firedEscalations: {
+			type: [String],
+			default: [],
+		},
 	},
 	{ timestamps: true }
 );

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -1,5 +1,5 @@
 import { Schema, model, Types } from "mongoose";
-import type { Monitor, MonitorMatchMethod, CheckSnapshot } from "@/types/monitor.js";
+import type { Monitor, MonitorMatchMethod, CheckSnapshot, EscalationRule } from "@/types/monitor.js";
 import { MonitorTypes, MonitorStatuses } from "@/types/monitor.js";
 import type {
 	CheckAudits,
@@ -16,13 +16,18 @@ import type {
 
 type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Date };
 
+type EscalationRuleDocument = Omit<EscalationRule, "notificationId"> & {
+	notificationId: Types.ObjectId;
+};
+
 type MonitorDocumentBase = Omit<
 	Monitor,
-	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
+	"id" | "userId" | "teamId" | "notifications" | "escalations" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
 > & {
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
+	escalations: EscalationRuleDocument[];
 	selectedDisks: string[];
 	matchMethod?: MonitorMatchMethod;
 };
@@ -282,6 +287,21 @@ const MonitorSchema = new Schema<MonitorDocument>(
 			{
 				type: Schema.Types.ObjectId,
 				ref: "Notification",
+			},
+		],
+		escalations: [
+			{
+				notificationId: {
+					type: Schema.Types.ObjectId,
+					ref: "Notification",
+					required: true,
+				},
+				delayMinutes: {
+					type: Number,
+					required: true,
+					min: 1,
+				},
+				_id: false,
 			},
 		],
 		secret: {

--- a/server/src/repositories/incidents/IIncidentsRepository.ts
+++ b/server/src/repositories/incidents/IIncidentsRepository.ts
@@ -22,6 +22,7 @@ export interface IIncidentsRepository {
 
 	// update
 	updateById(incidentId: string, teamId: string, updateData: Partial<Incident>): Promise<Incident>;
+	addFiredEscalation(incidentId: string, teamId: string, notificationId: string): Promise<Incident>;
 	// delete
 	deleteByMonitorId(monitorId: string, teamId: string): Promise<number>;
 	deleteByMonitorIdsNotIn(monitorIds: string[]): Promise<number>;

--- a/server/src/repositories/incidents/MongoIncidentRepository.ts
+++ b/server/src/repositories/incidents/MongoIncidentRepository.ts
@@ -60,6 +60,7 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			resolvedBy: doc.resolvedBy ? this.toStringId(doc.resolvedBy) : null,
 			resolvedByEmail: doc.resolvedByEmail ?? null,
 			comment: doc.comment ?? null,
+			firedEscalations: (doc as unknown as { firedEscalations?: string[] }).firedEscalations ?? [],
 			createdAt: this.toDateString(doc.createdAt),
 			updatedAt: this.toDateString(doc.updatedAt),
 		};
@@ -147,6 +148,22 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			throw new AppError({ message: `Failed to update incident with id ${incidentId}`, status: 500 });
 		}
 		return this.toEntity(updatedIncident);
+	};
+
+	addFiredEscalation = async (incidentId: string, teamId: string, notificationId: string): Promise<Incident> => {
+		const updated = await IncidentModel.findOneAndUpdate(
+			{
+				_id: new mongoose.Types.ObjectId(incidentId),
+				teamId: new mongoose.Types.ObjectId(teamId),
+				status: true,
+			},
+			{ $addToSet: { firedEscalations: notificationId } },
+			{ new: true }
+		);
+		if (!updated) {
+			throw new AppError({ message: `Failed to update escalation for incident ${incidentId}`, status: 500 });
+		}
+		return this.toEntity(updated);
 	};
 
 	countByTeamId = async (

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -351,6 +351,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification) => toStringId(notification));
+		const escalationRules = (doc.escalations ?? []).map((esc) => ({
+			notificationId: toStringId(esc.notificationId),
+			delayMinutes: esc.delayMinutes,
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -374,6 +378,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalations: escalationRules,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -410,6 +415,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification: unknown) => toStringId(notification));
+		const escalationRules = ((doc as unknown as { escalations?: Array<{ notificationId: unknown; delayMinutes: number }> }).escalations ?? []).map((esc) => ({
+			notificationId: toStringId(esc.notificationId),
+			delayMinutes: esc.delayMinutes,
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -433,6 +442,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalations: escalationRules,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/business/monitorService.ts
+++ b/server/src/service/business/monitorService.ts
@@ -567,6 +567,7 @@ export class MonitorService implements IMonitorService {
 			id: "",
 			teamId,
 			userId,
+			escalations: [],
 			recentChecks: [],
 			createdAt: "",
 			updatedAt: "",

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -177,6 +177,18 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 						stack: error instanceof Error ? error.stack : undefined,
 					});
 				});
+
+				// Step 8. Check escalations (best effort, don't wait)
+				if (statusChangeResult.monitor.escalations && statusChangeResult.monitor.escalations.length > 0) {
+					this.checkEscalations(statusChangeResult.monitor).catch((error: unknown) => {
+						this.logger.warn({
+							message: `Error checking escalations for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+							service: SERVICE_NAME,
+							method: "getMonitorJob",
+							stack: error instanceof Error ? error.stack : undefined,
+						});
+					});
+				}
 			} catch (error: unknown) {
 				this.logger.warn({
 					message: error instanceof Error ? error.message : "Unknown error",
@@ -417,6 +429,44 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 			}
 		};
 	};
+
+	private async checkEscalations(monitor: Monitor): Promise<void> {
+		const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId);
+		if (!activeIncident) {
+			return;
+		}
+
+		const incidentStartMs = new Date(activeIncident.startTime).getTime();
+		const nowMs = Date.now();
+		const elapsedMinutes = (nowMs - incidentStartMs) / 60000;
+
+		for (const escalation of monitor.escalations) {
+			if (elapsedMinutes < escalation.delayMinutes) {
+				continue;
+			}
+
+			if (activeIncident.firedEscalations.includes(escalation.notificationId)) {
+				continue;
+			}
+
+			this.logger.info({
+				message: `Firing escalation for monitor ${monitor.id}: notification ${escalation.notificationId} after ${escalation.delayMinutes} min`,
+				service: SERVICE_NAME,
+				method: "checkEscalations",
+			});
+
+			const sent = await this.notificationsService.sendEscalationNotification(
+				monitor,
+				escalation.notificationId,
+				activeIncident.startTime,
+				escalation.delayMinutes
+			);
+
+			if (sent) {
+				await this.incidentsRepository.addFiredEscalation(activeIncident.id, monitor.teamId, escalation.notificationId);
+			}
+		}
+	}
 
 	private evaluateMonitorAction(statusChangeResult: StatusChangeResult): MonitorActionDecision {
 		const { monitor, statusChanged, prevStatus } = statusChangeResult;

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -15,6 +15,12 @@ export interface INotificationMessageBuilder {
 		decision: MonitorActionDecision,
 		clientHost: string
 	): NotificationMessage;
+	buildEscalationMessage(
+		monitor: Monitor,
+		incidentStartTime: string,
+		delayMinutes: number,
+		clientHost: string
+	): NotificationMessage;
 	extractThresholdBreaches(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): ThresholdBreach[];
 }
 
@@ -52,6 +58,50 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		};
 	}
 
+	buildEscalationMessage(
+		monitor: Monitor,
+		incidentStartTime: string,
+		delayMinutes: number,
+		clientHost: string
+	): NotificationMessage {
+		const startDate = new Date(incidentStartTime);
+		const elapsedMs = Date.now() - startDate.getTime();
+		const elapsedMinutes = Math.round(elapsedMs / 60000);
+
+		const title = `Escalation: ${monitor.name}`;
+		const summary = `Monitor "${monitor.name}" has been ${monitor.status === "breached" ? "breached" : "down"} for ${elapsedMinutes} minute${elapsedMinutes !== 1 ? "s" : ""} (escalation trigger: ${delayMinutes} min).`;
+		const details = [
+			`URL: ${monitor.url}`,
+			`Status: ${monitor.status}`,
+			`Type: ${monitor.type}`,
+			`Incident started: ${startDate.toISOString()}`,
+			`Escalation delay: ${delayMinutes} minute${delayMinutes !== 1 ? "s" : ""}`,
+		];
+
+		return {
+			type: "escalation",
+			severity: "critical",
+			monitor: {
+				id: monitor.id,
+				name: monitor.name,
+				url: monitor.url,
+				type: monitor.type,
+				status: monitor.status,
+			},
+			content: {
+				title,
+				summary,
+				details,
+				timestamp: new Date(),
+			},
+			clientHost,
+			metadata: {
+				teamId: monitor.teamId,
+				notificationReason: "escalation",
+			},
+		};
+	}
+
 	private determineNotificationType(decision: MonitorActionDecision, monitor: Monitor): NotificationType {
 		// Down status has highest priority (critical)
 		if (monitor.status === "down") {
@@ -80,6 +130,7 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	private determineSeverity(type: NotificationType): NotificationSeverity {
 		switch (type) {
 			case "monitor_down":
+			case "escalation":
 				return "critical";
 			case "threshold_breach":
 				return "warning";

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -87,6 +87,8 @@ export class EmailProvider implements INotificationProvider {
 				return `Monitor ${message.monitor.name} threshold exceeded`;
 			case "threshold_resolved":
 				return `Monitor ${message.monitor.name} thresholds resolved`;
+			case "escalation":
+				return `ESCALATION: Monitor ${message.monitor.name} still ${message.monitor.status}`;
 			default:
 				return `Alert: ${message.monitor.name}`;
 		}

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,6 +14,7 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	sendEscalationNotification: (monitor: Monitor, notificationId: string, incidentStartTime: string, delayMinutes: number) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -139,6 +140,35 @@ export class NotificationsService implements INotificationsService {
 
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	sendEscalationNotification = async (monitor: Monitor, notificationId: string, incidentStartTime: string, delayMinutes: number): Promise<boolean> => {
+		try {
+			const notifications = await this.notificationsRepository.findNotificationsByIds([notificationId]);
+			if (notifications.length === 0) {
+				this.logger.warn({
+					message: `Escalation notification ${notificationId} not found`,
+					service: SERVICE_NAME,
+					method: "sendEscalationNotification",
+				});
+				return false;
+			}
+
+			const notification = notifications[0]!;
+			const settings = this.settingsService.getSettings();
+			const clientHost = settings.clientHost || "Host not defined";
+			const message = this.notificationMessageBuilder.buildEscalationMessage(monitor, incidentStartTime, delayMinutes, clientHost);
+
+			return await this.send(notification, monitor, {} as MonitorStatusResponse, {} as MonitorActionDecision, message);
+		} catch (error: unknown) {
+			this.logger.error({
+				message: `Failed to send escalation notification: ${error instanceof Error ? error.message : "Unknown error"}`,
+				service: SERVICE_NAME,
+				method: "sendEscalationNotification",
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+			return false;
+		}
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/service/infrastructure/statusService.ts
+++ b/server/src/service/infrastructure/statusService.ts
@@ -238,7 +238,9 @@ export class StatusService implements IStatusService {
 
 			// Return early if not enough data points
 			if (monitor.statusWindow.length < monitor.statusWindowSize) {
-				monitor.status = newStatus;
+				// Keep the current status during warmup so the first real
+				// threshold breach still produces a transition event.
+				monitor.status = prevStatus;
 				const updated = await this.monitorsRepository.updateById(monitor.id, monitor.teamId, monitor);
 				return {
 					monitor: updated,

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -16,6 +16,7 @@ export interface Incident {
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;
 	comment?: string | null;
+	firedEscalations: string[];
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface EscalationRule {
+	notificationId: string;
+	delayMinutes: number;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +42,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalations: EscalationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/types/notificationMessage.ts
+++ b/server/src/types/notificationMessage.ts
@@ -3,7 +3,7 @@
  * Part of notification system unification effort
  */
 
-export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test";
+export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "escalation" | "test";
 
 export type NotificationSeverity = "critical" | "warning" | "info" | "success";
 

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -49,6 +49,11 @@ export const getCertificateParamValidation = z.object({
 	monitorId: z.string().min(1, "Monitor ID is required"),
 });
 
+const escalationRuleValidation = z.object({
+	notificationId: z.string().min(1, "Notification ID is required"),
+	delayMinutes: z.number().min(1, "Delay must be at least 1 minute").max(1440, "Delay cannot exceed 24 hours"),
+});
+
 export const createMonitorBodyValidation = z.object({
 	_id: z.string().optional(),
 	name: z.string().min(1, "Name is required"),
@@ -67,6 +72,7 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalations: z.array(escalationRuleValidation).optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +95,7 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalations: z.array(escalationRuleValidation).optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),


### PR DESCRIPTION
## Describe your changes

This PR adds notification escalation support for monitors so alerts can be sent to a configured notification channel after an incident remains unresolved for a specified amount of time.

### What changed
- Added monitor-level escalation configuration with `delayMinutes` and `notificationId`
- Added escalation handling in the queue flow so active incidents can trigger delayed follow-up alerts
- Added escalation tracking on incidents to avoid sending the same escalation more than once per incident
- Added frontend support for configuring escalation rules on the monitor form
- Added a regression test and fixed a status warmup bug where newly failing monitors could enter `down` too early without creating an incident, which prevented escalations from ever firing

### Why
Previously, monitors could only send the initial notification when status changed. This change allows persistent incidents to notify the appropriate channel again after a delay if the issue is still unresolved.

## Write your issue number after "Fixes "

Fixes #1 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>