### PR TITLE
Feat/notification escalations

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalations: data?.escalations || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -776,65 +776,84 @@ const CreateMonitorPage = () => {
 							const escalationRules = field.value ?? [];
 							return (
 								<Stack spacing={theme.spacing(LAYOUT.MD)}>
-									{escalationRules.map((escalation: { delayMinutes: number; channelId: string }, index: number) => (
-										<Stack
-											key={index}
-											direction="row"
-											alignItems="center"
-											spacing={theme.spacing(SPACING.MD)}
-										>
-											<TextField
-												type="number"
-												fieldLabel={t("pages.createMonitor.form.escalation.option.delay.label")}
-												value={escalation.delayMinutes}
-												onChange={(e) => {
-													const newEscalations = [...escalationRules];
-													newEscalations[index] = {
-														...newEscalations[index],
-														delayMinutes: parseInt(e.target.value) || 0,
-													};
-													field.onChange(newEscalations);
-												}}
-												size="small"
-												sx={{ width: 120 }}
-											/>
-											<Select
-												fieldLabel={t("pages.createMonitor.form.escalation.option.channel.label")}
-												value={escalation.channelId}
-												onChange={(e) => {
-													const newEscalations = [...escalationRules];
-													newEscalations[index] = {
-														...newEscalations[index],
-														channelId: e.target.value,
-													};
-													field.onChange(newEscalations);
-												}}
-												size="small"
-												sx={{ minWidth: 200 }}
+									{escalationRules.map(
+										(
+											escalation: { delayMinutes: number; channelId: string },
+											index: number
+										) => (
+											<Stack
+												key={index}
+												direction="row"
+												alignItems="center"
+												spacing={theme.spacing(SPACING.MD)}
 											>
-												{notifications?.map((notification) => (
-													<MenuItem key={notification.id} value={notification.id}>
-														{notification.notificationName}
-													</MenuItem>
-												))}
-											</Select>
-											<IconButton
-												size="small"
-												onClick={() => {
-													const newEscalations = escalationRules.filter((_, i) => i !== index);
-													field.onChange(newEscalations);
-												}}
-												aria-label={t("pages.createMonitor.form.escalation.option.remove.ariaLabel")}
-											>
-												<Trash2 size={16} />
-											</IconButton>
-										</Stack>
-									))}
+												<TextField
+													type="number"
+													fieldLabel={t(
+														"pages.createMonitor.form.escalation.option.delay.label"
+													)}
+													value={escalation.delayMinutes}
+													onChange={(e) => {
+														const newEscalations = [...escalationRules];
+														newEscalations[index] = {
+															...newEscalations[index],
+															delayMinutes: parseInt(e.target.value) || 0,
+														};
+														field.onChange(newEscalations);
+													}}
+													size="small"
+													sx={{ width: 120 }}
+												/>
+												<Select
+													fieldLabel={t(
+														"pages.createMonitor.form.escalation.option.channel.label"
+													)}
+													value={escalation.channelId}
+													onChange={(e) => {
+														const newEscalations = [...escalationRules];
+														newEscalations[index] = {
+															...newEscalations[index],
+															channelId: e.target.value,
+														};
+														field.onChange(newEscalations);
+													}}
+													size="small"
+													sx={{ minWidth: 200 }}
+												>
+													{notifications?.map((notification) => (
+														<MenuItem
+															key={notification.id}
+															value={notification.id}
+														>
+															{notification.notificationName}
+														</MenuItem>
+													))}
+												</Select>
+												<IconButton
+													size="small"
+													onClick={() => {
+														const newEscalations = escalationRules.filter(
+															(_, i) => i !== index
+														);
+														field.onChange(newEscalations);
+													}}
+													aria-label={t(
+														"pages.createMonitor.form.escalation.option.remove.ariaLabel"
+													)}
+												>
+													<Trash2 size={16} />
+												</IconButton>
+											</Stack>
+										)
+									)}
 									<Button
 										variant="outlined"
 										size="small"
 										onClick={() => {
-											const newEscalations = [...escalationRules, { delayMinutes: 30, channelId: notifications?.[0]?.id || "" }];
+											const newEscalations = [
+												...escalationRules,
+												{ delayMinutes: 30, channelId: notifications?.[0]?.id || "" },
+											];
 											field.onChange(newEscalations);
 										}}
 									>

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -765,6 +765,88 @@ const CreateMonitorPage = () => {
 				}
 			/>
 
+			<ConfigBox
+				title="Escalation Rules"
+				subtitle="Configure escalation notifications for unacknowledged incidents"
+				rightContent={
+					<Controller
+						name="escalations"
+						control={control}
+						render={({ field }) => {
+							const escalationRules = field.value ?? [];
+							return (
+								<Stack spacing={theme.spacing(LAYOUT.MD)}>
+									{escalationRules.map((escalation: { delayMinutes: number; channelId: string }, index: number) => (
+										<Stack
+											key={index}
+											direction="row"
+											alignItems="center"
+											spacing={theme.spacing(SPACING.MD)}
+										>
+											<TextField
+												type="number"
+												fieldLabel="Delay (minutes)"
+												value={escalation.delayMinutes}
+												onChange={(e) => {
+													const newEscalations = [...escalationRules];
+													newEscalations[index] = {
+														...newEscalations[index],
+														delayMinutes: parseInt(e.target.value) || 0,
+													};
+													field.onChange(newEscalations);
+												}}
+												size="small"
+												sx={{ width: 120 }}
+											/>
+											<Select
+												fieldLabel="Channel"
+												value={escalation.channelId}
+												onChange={(e) => {
+													const newEscalations = [...escalationRules];
+													newEscalations[index] = {
+														...newEscalations[index],
+														channelId: e.target.value,
+													};
+													field.onChange(newEscalations);
+												}}
+												size="small"
+												sx={{ minWidth: 200 }}
+											>
+												{notifications?.map((notification) => (
+													<MenuItem key={notification.id} value={notification.id}>
+														{notification.notificationName}
+													</MenuItem>
+												))}
+											</Select>
+											<IconButton
+												size="small"
+												onClick={() => {
+													const newEscalations = escalationRules.filter((_, i) => i !== index);
+													field.onChange(newEscalations);
+												}}
+												aria-label="Remove escalation rule"
+											>
+												<Trash2 size={16} />
+											</IconButton>
+										</Stack>
+									))}
+									<Button
+										variant="outlined"
+										size="small"
+										onClick={() => {
+											const newEscalations = [...escalationRules, { delayMinutes: 30, channelId: notifications?.[0]?.id || "" }];
+											field.onChange(newEscalations);
+										}}
+									>
+										Add Escalation Rule
+									</Button>
+								</Stack>
+							);
+						}}
+					/>
+				}
+			/>
+
 			{(watchedType === "http" ||
 				watchedType === "grpc" ||
 				watchedType === "websocket") && (

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -766,8 +766,8 @@ const CreateMonitorPage = () => {
 			/>
 
 			<ConfigBox
-				title="Escalation Rules"
-				subtitle="Configure escalation notifications for unacknowledged incidents"
+				title={t("pages.createMonitor.form.escalation.title")}
+				subtitle={t("pages.createMonitor.form.escalation.description")}
 				rightContent={
 					<Controller
 						name="escalations"
@@ -785,7 +785,7 @@ const CreateMonitorPage = () => {
 										>
 											<TextField
 												type="number"
-												fieldLabel="Delay (minutes)"
+												fieldLabel={t("pages.createMonitor.form.escalation.option.delay.label")}
 												value={escalation.delayMinutes}
 												onChange={(e) => {
 													const newEscalations = [...escalationRules];
@@ -799,7 +799,7 @@ const CreateMonitorPage = () => {
 												sx={{ width: 120 }}
 											/>
 											<Select
-												fieldLabel="Channel"
+												fieldLabel={t("pages.createMonitor.form.escalation.option.channel.label")}
 												value={escalation.channelId}
 												onChange={(e) => {
 													const newEscalations = [...escalationRules];
@@ -824,7 +824,7 @@ const CreateMonitorPage = () => {
 													const newEscalations = escalationRules.filter((_, i) => i !== index);
 													field.onChange(newEscalations);
 												}}
-												aria-label="Remove escalation rule"
+												aria-label={t("pages.createMonitor.form.escalation.option.remove.ariaLabel")}
 											>
 												<Trash2 size={16} />
 											</IconButton>
@@ -838,7 +838,7 @@ const CreateMonitorPage = () => {
 											field.onChange(newEscalations);
 										}}
 									>
-										Add Escalation Rule
+										{t("pages.createMonitor.form.escalation.option.add")}
 									</Button>
 								</Stack>
 							);

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface MonitorEscalation {
+	delayMinutes: number;
+	channelId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -77,6 +82,7 @@ export interface Monitor {
 	geoCheckLocations?: GeoContinent[];
 	geoCheckInterval?: number;
 	recentChecks: CheckSnapshot[];
+	escalations?: MonitorEscalation[];
 	createdAt: string;
 	updatedAt: string;
 }

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -13,10 +13,14 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
-	escalations: z.array(z.object({
-		delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
-		channelId: z.string().min(1, "Channel is required"),
-	})).optional(),
+	escalations: z
+		.array(
+			z.object({
+				delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+				channelId: z.string().min(1, "Channel is required"),
+			})
+		)
+		.optional(),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -13,6 +13,10 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalations: z.array(z.object({
+		delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+		channelId: z.string().min(1, "Channel is required"),
+	})).optional(),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -622,6 +622,22 @@
 						"description": "This will permanently delete all monitoring history, statistics, and check data for your team. This action cannot be undone.",
 						"confirm": "Yes, clear all stats"
 					}
+				},
+				"escalation": {
+					"title": "Escalation Rules",
+					"description": "Configure escalation notifications for unacknowledged incidents",
+					"option": {
+						"delay": {
+							"label": "Delay (minutes)"
+						},
+						"channel": {
+							"label": "Channel"
+						},
+						"remove": {
+							"ariaLabel": "Remove escalation rule"
+						},
+						"add": "Add Escalation Rule"
+					}
 				}
 			}
 		},

--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -262,7 +262,9 @@ export const initializeServices = async ({
 		checksRepository,
 		incidentsRepository,
 		geoChecksService,
-		geoChecksRepository
+		geoChecksRepository,
+		notificationsRepository,
+		notificationMessageBuilder
 	);
 
 	const superSimpleQueue = await SuperSimpleQueue.create(logger, superSimpleQueueHelper, monitorsRepository);

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -49,6 +49,14 @@ const snapshotTimingPhasesSchema = new Schema<GotTimings["phases"]>(
 	{ _id: false }
 );
 
+const escalationSchema = new Schema(
+	{
+		delayMinutes: { type: Number, required: true },
+		channelId: { type: String, required: true },
+	},
+	{ _id: false }
+);
+
 const snapshotTimingsSchema = new Schema<GotTimings>(
 	{
 		start: { type: Number },
@@ -353,6 +361,10 @@ const MonitorSchema = new Schema<MonitorDocument>(
 		},
 		recentChecks: {
 			type: [checkSnapshotSchema],
+			default: [],
+		},
+		escalations: {
+			type: [escalationSchema],
 			default: [],
 		},
 	},

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -391,6 +391,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalations: doc.escalations ?? [],
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};
@@ -450,6 +451,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalations: doc.escalations ?? [],
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueue.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueue.ts
@@ -93,6 +93,7 @@ export class SuperSimpleQueue implements ISuperSimpleQueue {
 			this.scheduler.addTemplate("geo-check-job", this.helper.getHeartbeatGeoJob());
 			this.scheduler.addTemplate("cleanup-orphaned", this.helper.getCleanupOrphanedJob());
 			this.scheduler.addTemplate("cleanup-retention-job", this.helper.getCleanupRetentionJob());
+			this.scheduler.addTemplate("escalation-check", this.helper.getEscalationCheckJob());
 			const monitors = await this.monitorsRepository.findAll();
 			if (!monitors) {
 				return true;
@@ -106,6 +107,7 @@ export class SuperSimpleQueue implements ISuperSimpleQueue {
 
 			this.scheduler.addJob({ id: "cleanup-orphaned", template: "cleanup-orphaned", active: true });
 			this.scheduler.addJob({ id: "cleanup-retention", template: "cleanup-retention-job", active: true, repeat: 24 * 60 * 60 * 1000 });
+			this.scheduler.addJob({ id: "escalation-check", template: "escalation-check", active: true, repeat: 5 * 60 * 1000 }); // Every 5 minutes
 
 			return true;
 		} catch (error: unknown) {

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -440,8 +440,8 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 
 				// Get all monitors with escalations configured
 				const monitors = await this.monitorsRepository.findAll();
-				const monitorsWithEscalations = (monitors || []).filter(monitor => monitor.escalations && monitor.escalations.length > 0);
-				
+				const monitorsWithEscalations = (monitors || []).filter((monitor) => monitor.escalations && monitor.escalations.length > 0);
+
 				for (const monitor of monitorsWithEscalations) {
 					await this.checkAndTriggerEscalation(monitor);
 				}

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -20,9 +20,13 @@ import {
 	IChecksRepository,
 	IIncidentsRepository,
 	IGeoChecksRepository,
+	INotificationsRepository,
 } from "@/repositories/index.js";
 import { ILogger } from "@/utils/logger.js";
 import { IBufferService } from "@/service/index.js";
+import type { INotificationMessageBuilder } from "@/service/infrastructure/notificationMessageBuilder.js";
+import type { Incident } from "@/types/incident.js";
+import type { MonitorEscalation } from "@/types/monitor.js";
 
 export interface ISuperSimpleQueueHelper {
 	readonly serviceName: string;
@@ -30,6 +34,7 @@ export interface ISuperSimpleQueueHelper {
 	getHeartbeatGeoJob(): (monitor: Monitor) => Promise<void>;
 	getCleanupOrphanedJob(): () => Promise<void>;
 	getCleanupRetentionJob(): () => Promise<void>;
+	getEscalationCheckJob(): () => Promise<void>;
 	isInMaintenanceWindow(monitorId: string, teamId: string): Promise<boolean>;
 }
 
@@ -66,6 +71,8 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 	private incidentsRepository: IIncidentsRepository;
 	private geoChecksService: IGeoChecksService;
 	private geoChecksRepository: IGeoChecksRepository;
+	private notificationsRepository: INotificationsRepository;
+	private notificationMessageBuilder: INotificationMessageBuilder;
 
 	constructor(
 		logger: ILogger,
@@ -83,7 +90,9 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 		checksRepository: IChecksRepository,
 		incidentsRepository: IIncidentsRepository,
 		geoChecksService: IGeoChecksService,
-		geoChecksRepository: IGeoChecksRepository
+		geoChecksRepository: IGeoChecksRepository,
+		notificationsRepository: INotificationsRepository,
+		notificationMessageBuilder: INotificationMessageBuilder
 	) {
 		this.logger = logger;
 		this.networkService = networkService;
@@ -101,6 +110,8 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 		this.incidentsRepository = incidentsRepository;
 		this.geoChecksService = geoChecksService;
 		this.geoChecksRepository = geoChecksRepository;
+		this.notificationsRepository = notificationsRepository;
+		this.notificationMessageBuilder = notificationMessageBuilder;
 	}
 
 	get serviceName() {
@@ -416,6 +427,112 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 				});
 			}
 		};
+	};
+
+	getEscalationCheckJob = () => {
+		return async () => {
+			try {
+				this.logger.debug({
+					message: "Starting escalation check",
+					service: SERVICE_NAME,
+					method: "getEscalationCheckJob",
+				});
+
+				// Get all monitors with escalations configured
+				const monitors = await this.monitorsRepository.findAll();
+				const monitorsWithEscalations = (monitors || []).filter(monitor => monitor.escalations && monitor.escalations.length > 0);
+				
+				for (const monitor of monitorsWithEscalations) {
+					await this.checkAndTriggerEscalation(monitor);
+				}
+
+				this.logger.debug({
+					message: "Escalation check completed",
+					service: SERVICE_NAME,
+					method: "getEscalationCheckJob",
+				});
+			} catch (error: unknown) {
+				this.logger.error({
+					message: error instanceof Error ? error.message : "Unknown error",
+					service: SERVICE_NAME,
+					method: "getEscalationCheckJob",
+					stack: error instanceof Error ? error.stack : undefined,
+				});
+			}
+		};
+	};
+
+	private checkAndTriggerEscalation = async (monitor: Monitor) => {
+		try {
+			// Find active incident for this monitor
+			const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId);
+			if (!activeIncident) {
+				return; // No active incident, nothing to escalate
+			}
+
+			const incidentStartTime = new Date(activeIncident.startTime);
+			const now = new Date();
+			const incidentDurationMinutes = (now.getTime() - incidentStartTime.getTime()) / (1000 * 60);
+
+			// Check each escalation rule
+			for (const escalation of monitor.escalations || []) {
+				if (incidentDurationMinutes >= escalation.delayMinutes) {
+					// Check if we already sent this escalation (we could add a tracking mechanism later)
+					// For now, send it every time the job runs if the condition is met
+					await this.sendEscalationNotification(monitor, activeIncident, escalation);
+				}
+			}
+		} catch (error: unknown) {
+			this.logger.error({
+				message: `Error checking escalation for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+				service: SERVICE_NAME,
+				method: "checkAndTriggerEscalation",
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+		}
+	};
+
+	private sendEscalationNotification = async (monitor: Monitor, incident: Incident, escalation: MonitorEscalation) => {
+		try {
+			// Find the notification channel
+			const notification = await this.notificationsRepository.findById(escalation.channelId, monitor.teamId);
+			if (!notification) {
+				this.logger.warn({
+					message: `Escalation notification ${escalation.channelId} not found for monitor ${monitor.id}`,
+					service: SERVICE_NAME,
+					method: "sendEscalationNotification",
+				});
+				return;
+			}
+
+			// Build escalation message
+			const settings = this.settingsService.getSettings();
+			const clientHost = settings.clientHost || "Host not defined";
+			const escalationMessage = this.notificationMessageBuilder.buildEscalationMessage(monitor, incident, clientHost);
+
+			// Send the notification
+			const success = await this.notificationsService.sendNotification(notification, escalationMessage, monitor);
+			if (success) {
+				this.logger.info({
+					message: `Escalation notification sent for monitor ${monitor.id} via ${notification.type}`,
+					service: SERVICE_NAME,
+					method: "sendEscalationNotification",
+				});
+			} else {
+				this.logger.warn({
+					message: `Failed to send escalation notification for monitor ${monitor.id}`,
+					service: SERVICE_NAME,
+					method: "sendEscalationNotification",
+				});
+			}
+		} catch (error: unknown) {
+			this.logger.error({
+				message: `Error sending escalation notification for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+				service: SERVICE_NAME,
+				method: "sendEscalationNotification",
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+		}
 	};
 
 	private evaluateMonitorAction(statusChangeResult: StatusChangeResult): MonitorActionDecision {

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -1,4 +1,4 @@
-import type { HardwareStatusPayload, Monitor, MonitorStatusResponse } from "@/types/index.js";
+import type { HardwareStatusPayload, Monitor, MonitorStatusResponse, Incident } from "@/types/index.js";
 import type { MonitorActionDecision } from "@/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.js";
 import type {
 	NotificationMessage,
@@ -15,6 +15,7 @@ export interface INotificationMessageBuilder {
 		decision: MonitorActionDecision,
 		clientHost: string
 	): NotificationMessage;
+	buildEscalationMessage(monitor: Monitor, incident: Incident, clientHost: string): NotificationMessage;
 	extractThresholdBreaches(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): ThresholdBreach[];
 }
 
@@ -48,6 +49,30 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 			metadata: {
 				teamId: monitor.teamId,
 				notificationReason: decision.notificationReason || "status_change",
+			},
+		};
+	}
+
+	buildEscalationMessage(monitor: Monitor, incident: Incident, clientHost: string): NotificationMessage {
+		const type: NotificationType = "escalation";
+		const severity: NotificationSeverity = "critical";
+		const content = this.buildEscalationContent(monitor, incident);
+
+		return {
+			type,
+			severity,
+			monitor: {
+				id: monitor.id,
+				name: monitor.name,
+				url: monitor.url,
+				type: monitor.type,
+				status: monitor.status,
+			},
+			content,
+			clientHost,
+			metadata: {
+				teamId: monitor.teamId,
+				notificationReason: "escalation",
 			},
 		};
 	}
@@ -103,6 +128,9 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 				return this.buildThresholdBreachContent(monitor, monitorStatusResponse as MonitorStatusResponse<HardwareStatusPayload>);
 			case "threshold_resolved":
 				return this.buildThresholdResolvedContent(monitor);
+			case "escalation":
+				// This shouldn't be called for escalation, but fallback
+				return this.buildDefaultContent(monitor);
 			default:
 				return this.buildDefaultContent(monitor);
 		}
@@ -164,6 +192,24 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		const title = `Thresholds Resolved: ${monitor.name}`;
 		const summary = `Monitor "${monitor.name}" thresholds have returned to normal.`;
 		const details = [`URL: ${monitor.url}`, `Status: Up`, `Type: ${monitor.type}`];
+
+		return {
+			title,
+			summary,
+			details,
+			timestamp: new Date(),
+		};
+	}
+
+	private buildEscalationContent(monitor: Monitor, incident: Incident): NotificationContent {
+		const title = `ESCALATION: ${monitor.name}`;
+		const summary = `Monitor "${monitor.name}" has been down for an extended period and requires immediate attention.`;
+		const details = [
+			`URL: ${monitor.url}`,
+			`Status: ${monitor.status}`,
+			`Type: ${monitor.type}`,
+			`Incident started: ${new Date(incident.startTime).toISOString()}`,
+		];
 
 		return {
 			title,

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,7 +14,7 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
-
+	sendNotification: (notification: Notification, notificationMessage: NotificationMessage, monitor?: Monitor) => Promise<boolean>;
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
 }
@@ -67,9 +67,9 @@ export class NotificationsService implements INotificationsService {
 
 	private send = async (
 		notification: Notification,
-		monitor: Monitor,
-		monitorStatusResponse: MonitorStatusResponse,
-		decision: MonitorActionDecision,
+		monitor: Monitor | null,
+		monitorStatusResponse: MonitorStatusResponse | null,
+		decision: MonitorActionDecision | null,
 		notificationMessage: NotificationMessage | undefined
 	): Promise<boolean> => {
 		if (!notificationMessage) {
@@ -139,6 +139,10 @@ export class NotificationsService implements INotificationsService {
 
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	sendNotification = async (notification: Notification, notificationMessage: NotificationMessage, monitor?: Monitor) => {
+		return await this.send(notification, monitor || null, null, null, notificationMessage);
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface MonitorEscalation {
+	delayMinutes: number;
+	channelId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -54,6 +59,7 @@ export interface Monitor {
 	geoCheckLocations?: GeoContinent[];
 	geoCheckInterval?: number;
 	recentChecks: CheckSnapshot[];
+	escalations?: MonitorEscalation[];
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/types/notificationMessage.ts
+++ b/server/src/types/notificationMessage.ts
@@ -3,7 +3,7 @@
  * Part of notification system unification effort
  */
 
-export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test";
+export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "escalation" | "test";
 
 export type NotificationSeverity = "critical" | "warning" | "info" | "success";
 

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -78,10 +78,14 @@ export const createMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
-	escalations: z.array(z.object({
-		delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
-		channelId: z.string().min(1, "Channel is required"),
-	})).optional(),
+	escalations: z
+		.array(
+			z.object({
+				delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+				channelId: z.string().min(1, "Channel is required"),
+			})
+		)
+		.optional(),
 });
 
 export const editMonitorBodyValidation = z.object({
@@ -111,10 +115,14 @@ export const editMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
-	escalations: z.array(z.object({
-		delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
-		channelId: z.string().min(1, "Channel is required"),
-	})).optional(),
+	escalations: z
+		.array(
+			z.object({
+				delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+				channelId: z.string().min(1, "Channel is required"),
+			})
+		)
+		.optional(),
 });
 
 export const pauseMonitorParamValidation = z.object({

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -78,6 +78,10 @@ export const createMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalations: z.array(z.object({
+		delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+		channelId: z.string().min(1, "Channel is required"),
+	})).optional(),
 });
 
 export const editMonitorBodyValidation = z.object({
@@ -107,6 +111,10 @@ export const editMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalations: z.array(z.object({
+		delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+		channelId: z.string().min(1, "Channel is required"),
+	})).optional(),
 });
 
 export const pauseMonitorParamValidation = z.object({


### PR DESCRIPTION

Monitors can now have multiple escalation rules that send notifications to different channels after configurable delays (e.g., email immediately, then Slack after 30 minutes, then Discord after 2 hours). The system uses background jobs to handle timing and integrates with the existing notification infrastructure.
## Describe your changes

Briefly describe the changes you made and their purpose. 

## Write your issue number after "Fixes "

Fixes #1

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [ x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [ x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [ x] I have included the issue # in the PR.
- [ x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x ] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [ x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x ] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [ x] My PR is granular and targeted to one specific feature.
- [x ] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x ] I took a screenshot or a video and attached to this PR if there is a UI change.

<img width="1439" height="283" alt="Screenshot 2026-04-06 at 4 56 36 PM" src="https://github.com/user-attachments/assets/27d0c5a9-cf5d-4d5a-a90d-0bb61905b323" />
