### PR TITLE
add escalated notifications and incident flow fixes

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalatedNotifications: data?.escalatedNotifications || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -37,6 +37,7 @@ import {
 	type MonitorType,
 	type GamesMap,
 	supportsGeoCheck,
+	type EscalatedNotificationRule,
 } from "@/Types/Monitor";
 import type { Notification } from "@/Types/Notification";
 import type { MonitorFormData } from "@/Validation/monitor";
@@ -202,7 +203,7 @@ const CreateMonitorPage = () => {
 		resolver: zodResolver(schema),
 		defaultValues: defaults,
 	});
-	const { control, watch, handleSubmit, clearErrors } = form;
+	const { control, watch, handleSubmit, clearErrors, setValue } = form;
 
 	useEffect(() => {
 		form.reset(defaults);
@@ -220,6 +221,15 @@ const CreateMonitorPage = () => {
 	const generalSettingsConfig = useMemo(
 		() => getGeneralSettingsConfig(watchedType, t),
 		[watchedType, t]
+	);
+
+	const notificationOptions = useMemo(
+		() =>
+			(notifications ?? []).map((notification) => ({
+				...notification,
+				name: notification.notificationName,
+			})),
+		[notifications]
 	);
 
 	const { post, loading: isCreating } = usePost<MonitorFormData, Monitor>();
@@ -705,11 +715,6 @@ const CreateMonitorPage = () => {
 						name="notifications"
 						control={control}
 						render={({ field }) => {
-							// Map notifications to have 'name' property for Autocomplete
-							const notificationOptions = (notifications ?? []).map((n) => ({
-								...n,
-								name: n.notificationName,
-							}));
 							const selectedNotifications = notificationOptions.filter((n) =>
 								(field.value ?? []).includes(n.id)
 							);
@@ -765,35 +770,170 @@ const CreateMonitorPage = () => {
 				}
 			/>
 
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalations.title")}
+				subtitle={t("pages.createMonitor.form.escalations.description")}
+				rightContent={
+					<Controller
+						name="escalatedNotifications"
+						control={control}
+						render={({ field, fieldState }) => {
+							const rules: EscalatedNotificationRule[] = field.value ?? [];
+
+							return (
+								<Stack spacing={theme.spacing(LAYOUT.MD)}>
+									{rules.map((rule, ruleIndex) => {
+										const selectedChannels = notificationOptions.filter((n) =>
+											rule.notificationChannels.includes(n.id)
+										);
+
+										return (
+											<Stack
+												key={`escalation-rule-${ruleIndex}`}
+												spacing={theme.spacing(LAYOUT.SM)}
+											>
+												<Stack
+													direction="row"
+													spacing={theme.spacing(LAYOUT.SM)}
+													alignItems="center"
+												>
+													<TextField
+														type="number"
+														fieldLabel={t(
+															"pages.createMonitor.form.escalations.delayMinutes"
+														)}
+														value={rule.delayMinutes}
+														onChange={(event) => {
+															const nextRules = [...rules];
+															nextRules[ruleIndex] = {
+																...nextRules[ruleIndex],
+																delayMinutes: Number(event.target.value),
+															};
+															field.onChange(nextRules);
+														}}
+														fullWidth
+													/>
+													<IconButton
+														size="small"
+														onClick={() => {
+															const nextRules = rules.filter((_, index) => index !== ruleIndex);
+															field.onChange(nextRules);
+														}}
+														aria-label={t("pages.createMonitor.form.escalations.removeRule")}
+													>
+														<Trash2 size={16} />
+													</IconButton>
+												</Stack>
+
+												<Autocomplete
+													multiple
+													options={notificationOptions}
+													value={selectedChannels}
+													getOptionLabel={(option) => option.name}
+													onChange={(_: unknown, newValue: typeof notificationOptions) => {
+														const nextRules = [...rules];
+														nextRules[ruleIndex] = {
+															...nextRules[ruleIndex],
+															notificationChannels: newValue.map((notification) => notification.id),
+														};
+														field.onChange(nextRules);
+													}}
+													isOptionEqualToValue={(option, value) => option.id === value.id}
+													fieldLabel={t("pages.createMonitor.form.escalations.channels")}
+												/>
+												{selectedChannels.length > 0 && (
+													<Stack
+														flex={1}
+														width="100%"
+													>
+														{selectedChannels.map((notification, channelIndex) => (
+															<Stack
+																direction="row"
+																alignItems="center"
+																key={`${notification.id}-${channelIndex}`}
+																width="100%"
+															>
+																<Typography flexGrow={1}>{notification.notificationName}</Typography>
+																<IconButton
+																	size="small"
+																	onClick={() => {
+																		const nextRules = [...rules];
+																		nextRules[ruleIndex] = {
+																			...nextRules[ruleIndex],
+																			notificationChannels: nextRules[ruleIndex].notificationChannels.filter(
+																				(id: string) => id !== notification.id
+																			),
+																		};
+																		field.onChange(nextRules);
+																	}}
+																	aria-label={t("pages.createMonitor.form.escalations.removeRule")}
+																>
+																	<Trash2 size={16} />
+																</IconButton>
+																{channelIndex < selectedChannels.length - 1 && <Divider />}
+															</Stack>
+														))}
+													</Stack>
+												)}
+												{ruleIndex < rules.length - 1 && <Divider />}
+											</Stack>
+										);
+									})}
+									{fieldState.error?.message && (
+										<Typography color="error">{fieldState.error.message}</Typography>
+									)}
+									<Button
+										variant="outlined"
+										type="button"
+										onClick={() => {
+											const nextRules = [
+												...rules,
+												{ delayMinutes: 5, notificationChannels: [] },
+											];
+											setValue("escalatedNotifications", nextRules, {
+												shouldDirty: true,
+												shouldValidate: true,
+											});
+										}}
+									>
+										{t("pages.createMonitor.form.escalations.addRule")}
+									</Button>
+								</Stack>
+							);
+						}}
+					/>
+				}
+			/>
+
 			{(watchedType === "http" ||
 				watchedType === "grpc" ||
 				watchedType === "websocket") && (
-				<ConfigBox
-					title={t("pages.createMonitor.form.ignoreTls.title")}
-					subtitle={t("pages.createMonitor.form.ignoreTls.description")}
-					rightContent={
-						<Controller
-							name="ignoreTlsErrors"
-							control={control}
-							render={({ field }) => (
-								<Stack
-									direction="row"
-									alignItems="center"
-									spacing={theme.spacing(SPACING.LG)}
-								>
-									<Switch
-										checked={field.value ?? false}
-										onChange={(e) => field.onChange(e.target.checked)}
-									/>
-									<Typography>
-										{t("pages.createMonitor.form.ignoreTls.option.tls.label")}
-									</Typography>
-								</Stack>
-							)}
-						/>
-					}
-				/>
-			)}
+					<ConfigBox
+						title={t("pages.createMonitor.form.ignoreTls.title")}
+						subtitle={t("pages.createMonitor.form.ignoreTls.description")}
+						rightContent={
+							<Controller
+								name="ignoreTlsErrors"
+								control={control}
+								render={({ field }) => (
+									<Stack
+										direction="row"
+										alignItems="center"
+										spacing={theme.spacing(SPACING.LG)}
+									>
+										<Switch
+											checked={field.value ?? false}
+											onChange={(e) => field.onChange(e.target.checked)}
+										/>
+										<Typography>
+											{t("pages.createMonitor.form.ignoreTls.option.tls.label")}
+										</Typography>
+									</Stack>
+								)}
+							/>
+						}
+					/>
+				)}
 
 			{watchedType === "http" && (
 				<ConfigBox

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface EscalatedNotificationRule {
+	delayMinutes: number;
+	notificationChannels: string[];
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +65,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalatedNotifications?: EscalatedNotificationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -5,29 +5,57 @@ import { GeoContinents } from "@/Types/GeoCheck";
 const urlSchema = z.url({ message: "Please enter a valid URL" });
 
 // Common base schema for all monitor types
-const baseSchema = z.object({
-	name: z
-		.string()
-		.min(1, "Monitor name is required")
-		.max(50, "Monitor name must be at most 50 characters"),
-	description: z.string().optional(),
-	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
-	notifications: z.array(z.string()),
-	statusWindowSize: z
-		.number({ message: "Status window size is required" })
-		.min(1, "Status window size must be at least 1")
-		.max(25, "Status window size must be at most 25"),
-	statusWindowThreshold: z
-		.number({ message: "Threshold percentage is required" })
-		.min(1, "Incident percentage must be at least 1")
-		.max(100, "Incident percentage must be at most 100"),
-	geoCheckEnabled: z.boolean().optional(),
-	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
-	geoCheckInterval: z
-		.number()
-		.min(300000, "Interval must be at least 5 minutes")
-		.optional(),
-});
+const baseSchema = z
+	.object({
+		name: z
+			.string()
+			.min(1, "Monitor name is required")
+			.max(50, "Monitor name must be at most 50 characters"),
+		description: z.string().optional(),
+		interval: z.number().min(15000, "Interval must be at least 15 seconds"),
+		notifications: z.array(z.string()),
+		statusWindowSize: z
+			.number({ message: "Status window size is required" })
+			.min(1, "Status window size must be at least 1")
+			.max(25, "Status window size must be at most 25"),
+		statusWindowThreshold: z
+			.number({ message: "Threshold percentage is required" })
+			.min(1, "Incident percentage must be at least 1")
+			.max(100, "Incident percentage must be at most 100"),
+		escalatedNotifications: z
+			.array(
+				z.object({
+					delayMinutes: z
+						.number({ message: "Delay is required" })
+						.min(1, "Delay must be at least 1 minute")
+						.max(10080, "Delay must be at most 10080 minutes"),
+					notificationChannels: z.array(z.string()).min(1, "Select at least one notification channel"),
+				})
+			)
+			.optional()
+			.default([]),
+		geoCheckEnabled: z.boolean().optional(),
+		geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
+		geoCheckInterval: z
+			.number()
+			.min(300000, "Interval must be at least 5 minutes")
+			.optional(),
+	})
+	.superRefine((data, ctx) => {
+		const rules = data.escalatedNotifications ?? [];
+		const seenDelays = new Set<number>();
+
+		rules.forEach((rule, index) => {
+			if (seenDelays.has(rule.delayMinutes)) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "Delay minutes must be unique",
+					path: ["escalatedNotifications", index, "delayMinutes"],
+				});
+			}
+			seenDelays.add(rule.delayMinutes);
+		});
+	});
 
 // HTTP monitor schema
 const httpSchema = baseSchema.extend({

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -543,6 +543,14 @@
 					"description": "Select the notification channels you want to use",
 					"title": "Notifications"
 				},
+				"escalations": {
+					"title": "Escalation rules",
+					"description": "Define delayed escalation notifications to trigger if incidents continue.",
+					"addRule": "Add escalation rule",
+					"removeRule": "Remove escalation rule",
+					"delayMinutes": "Delay (minutes)",
+					"channels": "Notification channels"
+				},
 				"type": {
 					"description": "Select the type of check to perform",
 					"optionDockerDescription": "Use Docker to monitor if a container is running.",

--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -205,8 +205,6 @@ export const initializeServices = async ({
 
 	const notificationMessageBuilder = new NotificationMessageBuilder();
 
-	const incidentService = new IncidentService(logger, incidentsRepository, monitorsRepository, usersRepository, notificationMessageBuilder);
-
 	const checkService = new CheckService(monitorsRepository, logger, checksRepository);
 
 	const globalPingService = new GlobalPingService(logger);
@@ -244,6 +242,15 @@ export const initializeServices = async ({
 		settingsService,
 		logger,
 		notificationMessageBuilder
+	);
+
+	const incidentService = new IncidentService(
+		logger,
+		incidentsRepository,
+		monitorsRepository,
+		usersRepository,
+		notificationMessageBuilder,
+		notificationsService
 	);
 
 	const superSimpleQueueHelper = new SuperSimpleQueueHelper(

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -54,6 +54,10 @@ const IncidentSchema = new Schema<IncidentDocument>(
 			default: null,
 			index: true,
 		},
+		escalationsSent: {
+			type: [String],
+			default: [],
+		},
 		resolutionType: {
 			type: String,
 			enum: IncidentResolutionTypes,

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -1,5 +1,5 @@
 import { Schema, model, Types } from "mongoose";
-import type { Monitor, MonitorMatchMethod, CheckSnapshot } from "@/types/monitor.js";
+import type { Monitor, MonitorMatchMethod, CheckSnapshot, EscalatedNotificationRule } from "@/types/monitor.js";
 import { MonitorTypes, MonitorStatuses } from "@/types/monitor.js";
 import type {
 	CheckAudits,
@@ -15,14 +15,18 @@ import type {
 } from "@/types/check.js";
 
 type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Date };
+type EscalatedNotificationRuleDocument = Omit<EscalatedNotificationRule, "notificationChannels"> & {
+	notificationChannels: Types.ObjectId[];
+};
 
 type MonitorDocumentBase = Omit<
 	Monitor,
-	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
+	"id" | "userId" | "teamId" | "notifications" | "escalatedNotifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
 > & {
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
+	escalatedNotifications: EscalatedNotificationRuleDocument[];
 	selectedDisks: string[];
 	matchMethod?: MonitorMatchMethod;
 };
@@ -198,6 +202,20 @@ const checkSnapshotSchema = new Schema<CheckSnapshotDocument>(
 	{ _id: false }
 );
 
+const escalatedNotificationRuleSchema = new Schema<EscalatedNotificationRuleDocument>(
+	{
+		delayMinutes: { type: Number, required: true, min: 1 },
+		notificationChannels: [
+			{
+				type: Schema.Types.ObjectId,
+				ref: "Notification",
+				required: true,
+			},
+		],
+	},
+	{ _id: false }
+);
+
 const MonitorSchema = new Schema<MonitorDocument>(
 	{
 		userId: {
@@ -284,6 +302,10 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalatedNotifications: {
+			type: [escalatedNotificationRuleSchema],
+			default: [],
+		},
 		secret: {
 			type: String,
 		},

--- a/server/src/middleware/handleErrors.ts
+++ b/server/src/middleware/handleErrors.ts
@@ -1,22 +1,26 @@
 import type { NextFunction, Request, Response } from "express";
 import { logger } from "@/utils/logger.js";
 import { AppError } from "@/utils/AppError.js";
+import { ZodError } from "zod";
 
 const handleErrors = (error: unknown, req: Request, res: Response, _next: NextFunction) => {
-	const status = error instanceof AppError ? error.status || 500 : 500;
-	const message = error instanceof AppError ? error.message : "Server error";
-	const service = error instanceof AppError ? error.service : "unknownService";
-	const method = error instanceof AppError ? error.method : "unknownMethod";
+	const isAppError = error instanceof AppError;
+	const isZodError = error instanceof ZodError;
+	const status = isAppError ? error.status || 500 : isZodError ? 400 : 500;
+	const message = isAppError ? error.message : isZodError ? "Validation error" : "Server error";
+	const service = isAppError ? error.service : isZodError ? "Validation" : "unknownService";
+	const method = isAppError ? error.method : isZodError ? `${req.method} ${req.originalUrl}` : "unknownMethod";
 	logger.error({
 		message: message,
 		service: service,
 		method: method,
-		stack: error instanceof AppError ? error.stack : undefined,
-		details: error instanceof AppError ? error.details : undefined,
+		stack: isAppError ? error.stack : undefined,
+		details: isAppError ? error.details : isZodError ? error.flatten() : undefined,
 	});
 	res.status(status).json({
 		status,
 		msg: message,
+		...(isZodError ? { errors: error.flatten() } : {}),
 	});
 };
 

--- a/server/src/repositories/incidents/MongoIncidentRepository.ts
+++ b/server/src/repositories/incidents/MongoIncidentRepository.ts
@@ -56,6 +56,7 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			status: doc.status,
 			message: doc.message ?? null,
 			statusCode: doc.statusCode ?? null,
+			escalationsSent: doc.escalationsSent ?? [],
 			resolutionType: doc.resolutionType ?? null,
 			resolvedBy: doc.resolvedBy ? this.toStringId(doc.resolvedBy) : null,
 			resolvedByEmail: doc.resolvedByEmail ?? null,
@@ -254,10 +255,10 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			avgResolutionTimeHours,
 			topMonitor: monitorResult[0]
 				? {
-						monitorId: this.toStringId(monitorResult[0].monitorId),
-						monitorName: monitorResult[0].monitorName ?? null,
-						incidentCount: monitorResult[0].count,
-					}
+					monitorId: this.toStringId(monitorResult[0].monitorId),
+					monitorName: monitorResult[0].monitorName ?? null,
+					incidentCount: monitorResult[0].count,
+				}
 				: null,
 			latestIncidents: latestIncidents.map((incident) => ({
 				id: this.toStringId(incident._id),

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -17,7 +17,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		if (!monitors.length) {
 			return [];
 		}
-		const payload = monitors.map((monitor) => ({ ...monitor, notifications: undefined }));
+		const payload = monitors.map((monitor) => ({ ...monitor, notifications: undefined, escalatedNotifications: undefined }));
 		try {
 			const inserted = await MonitorModel.insertMany(payload, { ordered: false });
 			return this.mapDocuments(inserted);
@@ -293,7 +293,18 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 	};
 
 	removeNotificationFromMonitors = async (notificationId: string): Promise<void> => {
-		await MonitorModel.updateMany({ notifications: notificationId }, { $pull: { notifications: notificationId } });
+		const notificationObjectId = new mongoose.Types.ObjectId(notificationId);
+		await MonitorModel.updateMany(
+			{
+				$or: [{ notifications: notificationObjectId }, { "escalatedNotifications.notificationChannels": notificationObjectId }],
+			},
+			{
+				$pull: {
+					notifications: notificationObjectId,
+					"escalatedNotifications.$[].notificationChannels": notificationObjectId,
+				},
+			}
+		);
 	};
 
 	updateNotifications = async (
@@ -351,6 +362,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification) => toStringId(notification));
+		const escalatedNotifications = (doc.escalatedNotifications ?? []).map((rule) => ({
+			delayMinutes: rule.delayMinutes,
+			notificationChannels: (rule.notificationChannels ?? []).map((channel) => toStringId(channel)),
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -374,6 +389,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalatedNotifications,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -410,6 +426,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification: unknown) => toStringId(notification));
+		const escalatedNotifications = (doc.escalatedNotifications ?? []).map((rule) => ({
+			delayMinutes: rule.delayMinutes,
+			notificationChannels: (rule.notificationChannels ?? []).map((channel) => toStringId(channel)),
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -433,6 +453,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalatedNotifications,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/business/incidentService.ts
+++ b/server/src/service/business/incidentService.ts
@@ -7,6 +7,7 @@ import type { IIncidentsRepository, IMonitorsRepository, IUsersRepository } from
 import type { Incident, IncidentSummary, User } from "@/types/index.js";
 import type { MonitorActionDecision } from "@/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.js";
 import type { INotificationMessageBuilder } from "@/service/infrastructure/notificationMessageBuilder.js";
+import type { INotificationsService } from "@/service/infrastructure/notificationsService.js";
 import type { ILogger } from "@/utils/logger.js";
 
 export interface IIncidentService {
@@ -39,19 +40,22 @@ export class IncidentService implements IIncidentService {
 	private monitorsRepository: IMonitorsRepository;
 	private usersRepository: IUsersRepository;
 	private notificationMessageBuilder: INotificationMessageBuilder;
+	private notificationsService: INotificationsService;
 
 	constructor(
 		logger: ILogger,
 		incidentsRepository: IIncidentsRepository,
 		monitorsRepository: IMonitorsRepository,
 		usersRepository: IUsersRepository,
-		notificationMessageBuilder: INotificationMessageBuilder
+		notificationMessageBuilder: INotificationMessageBuilder,
+		notificationsService: INotificationsService
 	) {
 		this.logger = logger;
 		this.incidentsRepository = incidentsRepository;
 		this.monitorsRepository = monitorsRepository;
 		this.usersRepository = usersRepository;
 		this.notificationMessageBuilder = notificationMessageBuilder;
+		this.notificationsService = notificationsService;
 	}
 
 	get serviceName() {
@@ -64,11 +68,18 @@ export class IncidentService implements IIncidentService {
 		decision: MonitorActionDecision,
 		monitorStatusResponse?: MonitorStatusResponse
 	): Promise<Incident | null> => {
+		const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId);
+
+		await this.handleEscalations({
+			monitor,
+			activeIncident,
+			decision,
+			monitorStatusResponse,
+		});
+
 		if (!decision.shouldCreateIncident && !decision.shouldResolveIncident) {
 			return null;
 		}
-
-		const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId);
 
 		if (decision.shouldCreateIncident) {
 			if (activeIncident) {
@@ -89,6 +100,7 @@ export class IncidentService implements IIncidentService {
 					startTime: Date.now().toString(),
 					status: true,
 					statusCode,
+					escalationsSent: [],
 					message,
 				};
 				return await this.incidentsRepository.create(incident);
@@ -106,6 +118,90 @@ export class IncidentService implements IIncidentService {
 		}
 
 		return null;
+	};
+
+	private buildEscalationRuleKey(delayMinutes: number, notificationChannels: string[]): string {
+		const channelKey = [...notificationChannels].sort().join(",");
+		return `${delayMinutes}:${channelKey}`;
+	}
+
+	private handleEscalations = async ({
+		monitor,
+		activeIncident,
+		decision,
+		monitorStatusResponse,
+	}: {
+		monitor: Monitor;
+		activeIncident: Incident | null;
+		decision: MonitorActionDecision;
+		monitorStatusResponse?: MonitorStatusResponse;
+	}): Promise<void> => {
+		if (!activeIncident) {
+			return;
+		}
+
+		if (!monitorStatusResponse) {
+			return;
+		}
+
+		if (monitor.status !== "down" && monitor.status !== "breached") {
+			return;
+		}
+
+		const escalationRules = (monitor.escalatedNotifications ?? [])
+			.filter((rule) => rule.delayMinutes > 0 && Array.isArray(rule.notificationChannels) && rule.notificationChannels.length > 0)
+			.sort((a, b) => a.delayMinutes - b.delayMinutes);
+
+		if (!escalationRules.length) {
+			return;
+		}
+
+		const incidentStartedAt = new Date(activeIncident.startTime).getTime();
+		const incidentDurationMinutes = Math.floor((Date.now() - incidentStartedAt) / 60000);
+		if (incidentDurationMinutes <= 0) {
+			return;
+		}
+
+		const alreadySent = new Set(activeIncident.escalationsSent ?? []);
+		const sentThisCycle: string[] = [];
+
+		for (const rule of escalationRules) {
+			if (incidentDurationMinutes < rule.delayMinutes) {
+				continue;
+			}
+
+			const ruleKey = this.buildEscalationRuleKey(rule.delayMinutes, rule.notificationChannels);
+			if (alreadySent.has(ruleKey)) {
+				continue;
+			}
+
+			const success = await this.notificationsService.sendEscalationNotifications({
+				monitor,
+				monitorStatusResponse,
+				decision,
+				notificationIds: rule.notificationChannels,
+				escalationDelayMinutes: rule.delayMinutes,
+				incidentDurationMinutes,
+			});
+
+			if (!success) {
+				this.logger.warn({
+					message: `Escalation notification failed for monitor ${monitor.id} at ${rule.delayMinutes} minutes`,
+					service: SERVICE_NAME,
+					method: "handleEscalations",
+				});
+				continue;
+			}
+
+			alreadySent.add(ruleKey);
+			sentThisCycle.push(ruleKey);
+		}
+
+		if (sentThisCycle.length > 0) {
+			await this.incidentsRepository.updateById(activeIncident.id, activeIncident.teamId, {
+				escalationsSent: [...alreadySent],
+			});
+		}
 	};
 
 	private buildThresholdBreachMessage(monitor: Monitor, monitorStatusResponse?: MonitorStatusResponse): string {

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,6 +14,14 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	sendEscalationNotifications: (args: {
+		monitor: Monitor;
+		monitorStatusResponse: MonitorStatusResponse;
+		decision: MonitorActionDecision;
+		notificationIds: string[];
+		escalationDelayMinutes: number;
+		incidentDurationMinutes: number;
+	}) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -65,13 +73,7 @@ export class NotificationsService implements INotificationsService {
 		this.notificationMessageBuilder = notificationMessageBuilder;
 	}
 
-	private send = async (
-		notification: Notification,
-		monitor: Monitor,
-		monitorStatusResponse: MonitorStatusResponse,
-		decision: MonitorActionDecision,
-		notificationMessage: NotificationMessage | undefined
-	): Promise<boolean> => {
+	private send = async (notification: Notification, notificationMessage: NotificationMessage | undefined): Promise<boolean> => {
 		if (!notificationMessage) {
 			this.logger.warn({
 				message: "Notification message not provided",
@@ -109,14 +111,19 @@ export class NotificationsService implements INotificationsService {
 
 	private sendNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
 		const notificationIds = monitor.notifications ?? [];
-		const notifications = await this.notificationsRepository.findNotificationsByIds(notificationIds);
 
 		// Build notification message once for all notifications
 		const settings = this.settingsService.getSettings();
 		const clientHost = settings.clientHost || "Host not defined";
 		const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, decision, clientHost);
 
-		const tasks = notifications.map((notification) => this.send(notification, monitor, monitorStatusResponse, decision, notificationMessage));
+		return await this.sendNotificationsByIds(notificationIds, notificationMessage);
+	};
+
+	private sendNotificationsByIds = async (notificationIds: string[], notificationMessage: NotificationMessage) => {
+		const notifications = await this.notificationsRepository.findNotificationsByIds(notificationIds);
+
+		const tasks = notifications.map((notification) => this.send(notification, notificationMessage));
 
 		const outcomes = await Promise.all(tasks);
 		const succeeded = outcomes.filter(Boolean).length;
@@ -139,6 +146,50 @@ export class NotificationsService implements INotificationsService {
 
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	sendEscalationNotifications = async ({
+		monitor,
+		monitorStatusResponse,
+		decision,
+		notificationIds,
+		escalationDelayMinutes,
+		incidentDurationMinutes,
+	}: {
+		monitor: Monitor;
+		monitorStatusResponse: MonitorStatusResponse;
+		decision: MonitorActionDecision;
+		notificationIds: string[];
+		escalationDelayMinutes: number;
+		incidentDurationMinutes: number;
+	}) => {
+		if (!notificationIds.length) {
+			return true;
+		}
+
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+		const baseMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, decision, clientHost);
+		const escalationMessage: NotificationMessage = {
+			...baseMessage,
+			content: {
+				...baseMessage.content,
+				title: `Escalation: ${baseMessage.content.title}`,
+				summary: `Incident for monitor "${monitor.name}" remains unresolved after ${incidentDurationMinutes} minute(s).`,
+				details: [
+					...(baseMessage.content.details ?? []),
+					`Escalation delay: ${escalationDelayMinutes} minute(s)`,
+					`Current incident duration: ${incidentDurationMinutes} minute(s)`,
+				],
+				timestamp: new Date(),
+			},
+			metadata: {
+				...baseMessage.metadata,
+				notificationReason: "escalation",
+			},
+		};
+
+		return await this.sendNotificationsByIds(notificationIds, escalationMessage);
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/service/infrastructure/statusService.ts
+++ b/server/src/service/infrastructure/statusService.ts
@@ -239,10 +239,11 @@ export class StatusService implements IStatusService {
 			// Return early if not enough data points
 			if (monitor.statusWindow.length < monitor.statusWindowSize) {
 				monitor.status = newStatus;
+				const hasChangedDuringWarmup = prevStatus !== newStatus;
 				const updated = await this.monitorsRepository.updateById(monitor.id, monitor.teamId, monitor);
 				return {
 					monitor: updated,
-					statusChanged: false,
+					statusChanged: hasChangedDuringWarmup,
 					prevStatus,
 					code,
 					timestamp: Date.now(),

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -12,6 +12,7 @@ export interface Incident {
 	status: boolean;
 	message?: string | null;
 	statusCode?: number | null;
+	escalationsSent?: string[];
 	resolutionType: IncidentResolutionType;
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface EscalatedNotificationRule {
+	delayMinutes: number;
+	notificationChannels: string[];
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +42,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalatedNotifications?: EscalatedNotificationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/validation/incidentValidation.ts
+++ b/server/src/validation/incidentValidation.ts
@@ -6,10 +6,10 @@ import { booleanCoercion } from "./shared.js";
 //****************************************
 
 export const getIncidentsByTeamQueryValidation = z.object({
-	sortOrder: z.enum(["asc", "desc"]),
-	dateRange: z.enum(["recent", "hour", "day", "week", "month", "all"]),
-	page: z.coerce.number().int().min(0),
-	rowsPerPage: z.coerce.number().int().min(1),
+	sortOrder: z.enum(["asc", "desc"]).default("desc"),
+	dateRange: z.enum(["recent", "hour", "day", "week", "month", "all"]).default("recent"),
+	page: z.coerce.number().int().min(0).default(0),
+	rowsPerPage: z.coerce.number().int().min(1).default(20),
 	status: booleanCoercion.optional(),
 	monitorId: z.string().optional(),
 	resolutionType: z.enum(["manual", "automatic"]).optional(),

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -49,6 +49,25 @@ export const getCertificateParamValidation = z.object({
 	monitorId: z.string().min(1, "Monitor ID is required"),
 });
 
+const escalatedNotificationRuleValidation = z.object({
+	delayMinutes: z.number().min(1).max(10080),
+	notificationChannels: z.array(z.string()).min(1),
+});
+
+const escalatedNotificationsValidation = z.array(escalatedNotificationRuleValidation).superRefine((rules, ctx) => {
+	const seenDelays = new Set<number>();
+	rules.forEach((rule, index) => {
+		if (seenDelays.has(rule.delayMinutes)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Escalation delays must be unique",
+				path: [index, "delayMinutes"],
+			});
+		}
+		seenDelays.add(rule.delayMinutes);
+	});
+});
+
 export const createMonitorBodyValidation = z.object({
 	_id: z.string().optional(),
 	name: z.string().min(1, "Name is required"),
@@ -67,6 +86,7 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalatedNotifications: escalatedNotificationsValidation.optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +109,7 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalatedNotifications: escalatedNotificationsValidation.optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),
@@ -144,6 +165,7 @@ const importedMonitorSchema = z.object({
 	interval: z.number().default(60000),
 	uptimePercentage: z.number().optional(),
 	notifications: z.array(z.string()).default([]),
+	escalatedNotifications: escalatedNotificationsValidation.default([]),
 	secret: z.string().optional(),
 	cpuAlertThreshold: z.number().default(100),
 	cpuAlertCounter: z.number().default(5),


### PR DESCRIPTION
I added a feature for notification escalation, which will send additional notifications when a monitor goes down. Settings for this feature can be changed in the configuration menu for each monitor

Fixes #1

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.

