### PR TITLE
feat: add escalation rules for notifications and update incident hand…

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalations: data?.escalations || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -765,6 +765,106 @@ const CreateMonitorPage = () => {
 				}
 			/>
 
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalations.title")}
+				subtitle={t("pages.createMonitor.form.escalations.description")}
+				rightContent={
+					<Controller
+						name="escalations"
+						control={control}
+						render={({ field }) => {
+							const escalationRules = field.value ?? [];
+							const escalationDelayMinutes = escalationRules[0]?.delayMinutes ?? 0;
+							const notificationOptions = (notifications ?? []).map((notification) => ({
+								...notification,
+								name: notification.notificationName,
+							}));
+							const selectedChannelIds = [
+								...new Set(escalationRules.map((rule) => rule.channelId).filter(Boolean)),
+							];
+							const selectedChannels = notificationOptions.filter((notification) =>
+								selectedChannelIds.includes(notification.id)
+							);
+
+							const updateEscalations = (channelIds: string[], delayMinutes: number) => {
+								field.onChange(
+									channelIds.map((channelId) => ({ delayMinutes, channelId }))
+								);
+							};
+
+							return (
+								<Stack spacing={theme.spacing(LAYOUT.MD)}>
+									<TextField
+										type="number"
+										fieldLabel={t(
+											"pages.createMonitor.form.escalations.option.delayMinutes.label"
+										)}
+										value={escalationDelayMinutes}
+										onChange={(event) => {
+											const parsedValue = Number(event.target.value);
+											const nextDelay = Number.isFinite(parsedValue)
+												? Math.max(0, parsedValue)
+												: 0;
+											updateEscalations(selectedChannelIds, nextDelay);
+										}}
+									/>
+									<Autocomplete
+										multiple
+										options={notificationOptions}
+										value={selectedChannels}
+										getOptionLabel={(option) => option.name}
+										onChange={(_: unknown, newValue: typeof notificationOptions) => {
+											updateEscalations(
+												newValue.map((notification) => notification.id),
+												escalationDelayMinutes
+											);
+										}}
+										isOptionEqualToValue={(option, value) => option.id === value.id}
+										fieldLabel={t(
+											"pages.createMonitor.form.escalations.option.channelId.label"
+										)}
+									/>
+									{selectedChannels.length > 0 && (
+										<Stack
+											flex={1}
+											width="100%"
+										>
+											{selectedChannels.map((notification, index) => (
+												<Stack
+													direction="row"
+													alignItems="center"
+													key={notification.id}
+													width="100%"
+												>
+													<Typography flexGrow={1}>
+														{notification.notificationName}
+													</Typography>
+													<IconButton
+														size="small"
+														onClick={() => {
+															updateEscalations(
+																selectedChannelIds.filter((id) => id !== notification.id),
+																escalationDelayMinutes
+															);
+														}}
+														aria-label={t(
+															"pages.createMonitor.form.escalations.option.remove.label"
+														)}
+													>
+														<Trash2 size={16} />
+													</IconButton>
+													{index < selectedChannels.length - 1 && <Divider />}
+												</Stack>
+											))}
+										</Stack>
+									)}
+								</Stack>
+							);
+						}}
+					/>
+				}
+			/>
+
 			{(watchedType === "http" ||
 				watchedType === "grpc" ||
 				watchedType === "websocket") && (

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface MonitorEscalation {
+	delayMinutes: number;
+	channelId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +65,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalations?: MonitorEscalation[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -13,6 +13,17 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalations: z
+		.array(
+			z.object({
+				delayMinutes: z
+					.number()
+					.int()
+					.min(0, "Escalation delay must be at least 0 minutes"),
+				channelId: z.string().min(1, "Escalation channel is required"),
+			})
+		)
+		.default([]),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")
@@ -135,7 +146,7 @@ export const monitorSchema = z.discriminatedUnion("type", [
 	websocketSchema,
 ]);
 
-export type MonitorFormData = z.infer<typeof monitorSchema>;
+export type MonitorFormData = z.input<typeof monitorSchema>;
 
 // Type-specific schemas exported for individual use
 export {

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -543,6 +543,25 @@
 					"description": "Select the notification channels you want to use",
 					"title": "Notifications"
 				},
+				"escalations": {
+					"title": "Escalation Rules",
+					"description": "If an incident remains unresolved, trigger additional channels after the configured delay.",
+					"option": {
+						"delayMinutes": {
+							"label": "Escalate after (minutes)"
+						},
+						"channelId": {
+							"label": "Escalation notification channel",
+							"placeholder": "Select a notification channel"
+						},
+						"add": {
+							"label": "Add escalation rule"
+						},
+						"remove": {
+							"label": "Remove escalation rule"
+						}
+					}
+				},
 				"type": {
 					"description": "Select the type of check to perform",
 					"optionDockerDescription": "Use Docker to monitor if a container is running.",

--- a/server/src/controllers/monitorController.ts
+++ b/server/src/controllers/monitorController.ts
@@ -19,7 +19,6 @@ import sslChecker from "ssl-checker";
 import { fetchMonitorCertificate, requireTeamId, requireUserId } from "@/controllers/controllerUtils.js";
 import { AppError } from "@/utils/AppError.js";
 import { IMonitorService, INotificationsService } from "@/service/index.js";
-import { GeoContinent } from "@/types/geoCheck.js";
 
 const SERVICE_NAME = "monitorController";
 
@@ -58,6 +57,32 @@ class MonitorController implements IMonitorController {
 	get serviceName() {
 		return MonitorController.SERVICE_NAME;
 	}
+
+	private validateTeamNotificationAccess = async ({
+		teamId,
+		notificationIds = [],
+		escalationChannelIds = [],
+	}: {
+		teamId: string;
+		notificationIds?: string[];
+		escalationChannelIds?: string[];
+	}) => {
+		const requestedIds = [...new Set([...(notificationIds ?? []), ...(escalationChannelIds ?? [])])];
+		if (requestedIds.length === 0) {
+			return;
+		}
+
+		const teamNotifications = await this.notificationsService.findNotificationsByTeamId(teamId);
+		const validIds = new Set(teamNotifications.map((notification) => notification.id));
+		const invalidIds = requestedIds.filter((id) => !validIds.has(id));
+
+		if (invalidIds.length > 0) {
+			throw new AppError({
+				message: `The following notification IDs are invalid or do not belong to your team: ${invalidIds.join(", ")}`,
+				status: 403,
+			});
+		}
+	};
 
 	getMonitorCertificate = async (req: Request, res: Response, next: NextFunction) => {
 		try {
@@ -205,6 +230,11 @@ class MonitorController implements IMonitorController {
 
 			const userId = requireUserId(req.user?.id);
 			const teamId = requireTeamId(req.user?.teamId);
+			await this.validateTeamNotificationAccess({
+				teamId,
+				notificationIds: validatedBody.notifications,
+				escalationChannelIds: (validatedBody.escalations ?? []).map((escalation: { channelId: string }) => escalation.channelId),
+			});
 
 			const monitor = await this.monitorService.createMonitor(teamId, userId, validatedBody);
 
@@ -275,6 +305,11 @@ class MonitorController implements IMonitorController {
 			const validatedBody = editMonitorBodyValidation.parse(req.body);
 			const monitorId = validatedParams.monitorId;
 			const teamId = requireTeamId(req.user?.teamId);
+			await this.validateTeamNotificationAccess({
+				teamId,
+				notificationIds: validatedBody.notifications,
+				escalationChannelIds: (validatedBody.escalations ?? []).map((escalation: { channelId: string }) => escalation.channelId),
+			});
 
 			const editedMonitor = await this.monitorService.editMonitor({ teamId, monitorId, body: validatedBody });
 

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -72,6 +72,10 @@ const IncidentSchema = new Schema<IncidentDocument>(
 			type: String,
 			default: null,
 		},
+		escalationChannelsSent: {
+			type: [String],
+			default: [],
+		},
 	},
 	{ timestamps: true }
 );

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -15,15 +15,17 @@ import type {
 } from "@/types/check.js";
 
 type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Date };
+type MonitorEscalationDocument = { delayMinutes: number; channelId: Types.ObjectId };
 
 type MonitorDocumentBase = Omit<
 	Monitor,
-	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
+	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "escalations" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
 > & {
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
 	selectedDisks: string[];
+	escalations: MonitorEscalationDocument[];
 	matchMethod?: MonitorMatchMethod;
 };
 
@@ -198,6 +200,22 @@ const checkSnapshotSchema = new Schema<CheckSnapshotDocument>(
 	{ _id: false }
 );
 
+const escalationSchema = new Schema<MonitorEscalationDocument>(
+	{
+		delayMinutes: {
+			type: Number,
+			min: 0,
+			required: true,
+		},
+		channelId: {
+			type: Schema.Types.ObjectId,
+			ref: "Notification",
+			required: true,
+		},
+	},
+	{ _id: false }
+);
+
 const MonitorSchema = new Schema<MonitorDocument>(
 	{
 		userId: {
@@ -284,6 +302,10 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalations: {
+			type: [escalationSchema],
+			default: [],
+		},
 		secret: {
 			type: String,
 		},

--- a/server/src/repositories/incidents/MongoIncidentRepository.ts
+++ b/server/src/repositories/incidents/MongoIncidentRepository.ts
@@ -60,6 +60,7 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			resolvedBy: doc.resolvedBy ? this.toStringId(doc.resolvedBy) : null,
 			resolvedByEmail: doc.resolvedByEmail ?? null,
 			comment: doc.comment ?? null,
+			escalationChannelsSent: doc.escalationChannelsSent ?? [],
 			createdAt: this.toDateString(doc.createdAt),
 			updatedAt: this.toDateString(doc.updatedAt),
 		};

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -293,7 +293,17 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 	};
 
 	removeNotificationFromMonitors = async (notificationId: string): Promise<void> => {
-		await MonitorModel.updateMany({ notifications: notificationId }, { $pull: { notifications: notificationId } });
+		await MonitorModel.updateMany(
+			{
+				$or: [{ notifications: notificationId }, { "escalations.channelId": new mongoose.Types.ObjectId(notificationId) }],
+			},
+			{
+				$pull: {
+					notifications: notificationId,
+					escalations: { channelId: new mongoose.Types.ObjectId(notificationId) },
+				},
+			}
+		);
 	};
 
 	updateNotifications = async (
@@ -351,6 +361,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification) => toStringId(notification));
+		const escalations = (doc.escalations ?? []).map((escalation) => ({
+			delayMinutes: escalation.delayMinutes,
+			channelId: toStringId(escalation.channelId),
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -374,6 +388,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalations,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -410,6 +425,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification: unknown) => toStringId(notification));
+		const escalations = (doc.escalations ?? []).map((escalation) => ({
+			delayMinutes: escalation.delayMinutes,
+			channelId: toStringId(escalation.channelId),
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -433,6 +452,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalations,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/business/incidentService.ts
+++ b/server/src/service/business/incidentService.ts
@@ -90,6 +90,7 @@ export class IncidentService implements IIncidentService {
 					status: true,
 					statusCode,
 					message,
+					escalationChannelsSent: [],
 				};
 				return await this.incidentsRepository.create(incident);
 			}

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -2,6 +2,7 @@ const SERVICE_NAME = "JobQueueHelper";
 import type { Monitor } from "@/types/monitor.js";
 import { supportsGeoCheck } from "@/types/monitor.js";
 import { AppError } from "@/utils/AppError.js";
+import type { MonitorStatusResponse } from "@/types/network.js";
 import {
 	ICheckService,
 	INetworkService,
@@ -11,7 +12,7 @@ import {
 	IncidentService,
 	type IGeoChecksService,
 } from "@/service/index.js";
-import { CHECK_TTL_SENTINEL, type MaintenanceWindow, type StatusChangeResult } from "@/types/index.js";
+import { CHECK_TTL_SENTINEL, type Incident, type MaintenanceWindow, type StatusChangeResult } from "@/types/index.js";
 import {
 	IMaintenanceWindowsRepository,
 	IMonitorsRepository,
@@ -168,15 +169,9 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 					});
 				}
 
-				// Step 7. Handle incidents (best effort, don't wait)
-				this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status).catch((error: unknown) => {
-					this.logger.warn({
-						message: `Error handling incident for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
-						service: SERVICE_NAME,
-						method: "getMonitorJob",
-						stack: error instanceof Error ? error.stack : undefined,
-					});
-				});
+				// Step 7. Handle incidents and escalations
+				const incident = await this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status);
+				await this.handleEscalations(statusChangeResult.monitor, status, incident);
 			} catch (error: unknown) {
 				this.logger.warn({
 					message: error instanceof Error ? error.message : "Unknown error",
@@ -454,5 +449,52 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 		}
 
 		return decision;
+	}
+
+	private async handleEscalations(monitor: Monitor, status: MonitorStatusResponse, incidentFromDecision: Incident | null) {
+		if (monitor.status !== "down" && monitor.status !== "breached") {
+			return;
+		}
+
+		const escalationRules = (monitor.escalations ?? [])
+			.filter((rule) => Boolean(rule.channelId) && Number.isFinite(rule.delayMinutes) && rule.delayMinutes >= 0)
+			.sort((a, b) => a.delayMinutes - b.delayMinutes);
+
+		if (escalationRules.length === 0) {
+			return;
+		}
+
+		const activeIncident = incidentFromDecision ?? (await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId));
+		if (!activeIncident || !activeIncident.status) {
+			return;
+		}
+
+		const startTimeMs = new Date(activeIncident.startTime).getTime();
+		if (Number.isNaN(startTimeMs)) {
+			return;
+		}
+
+		const elapsedMinutes = (Date.now() - startTimeMs) / (60 * 1000);
+		const sentChannels = new Set(activeIncident.escalationChannelsSent ?? []);
+		const dueChannelIds = [
+			...new Set(
+				escalationRules.filter((rule) => elapsedMinutes >= rule.delayMinutes && !sentChannels.has(rule.channelId)).map((rule) => rule.channelId)
+			),
+		];
+
+		if (dueChannelIds.length === 0) {
+			return;
+		}
+
+		const reason: "status_change" | "threshold_breach" = activeIncident.statusCode === 9999 ? "threshold_breach" : "status_change";
+		const sentNow = await this.notificationsService.sendEscalationNotifications(monitor, status, dueChannelIds, reason);
+
+		if (sentNow.length === 0) {
+			return;
+		}
+
+		await this.incidentsRepository.updateById(activeIncident.id, activeIncident.teamId, {
+			escalationChannelsSent: [...new Set([...(activeIncident.escalationChannelsSent ?? []), ...sentNow])],
+		});
 	}
 }

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -80,6 +80,9 @@ export class EmailProvider implements INotificationProvider {
 	private buildSubject(message: NotificationMessage): string {
 		switch (message.type) {
 			case "monitor_down":
+				if (message.metadata.isEscalation) {
+					return `Escalation: Monitor ${message.monitor.name} still down`;
+				}
 				return `Monitor ${message.monitor.name} is down`;
 			case "monitor_up":
 				return `Monitor ${message.monitor.name} is back up`;

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,6 +14,13 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	sendEscalationNotifications: (
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		notificationIds: string[],
+		reason: "status_change" | "threshold_breach",
+		escalationDowntimeMinutes?: number
+	) => Promise<string[]>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -139,6 +146,74 @@ export class NotificationsService implements INotificationsService {
 
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	sendEscalationNotifications = async (
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		notificationIds: string[],
+		reason: "status_change" | "threshold_breach",
+		escalationDowntimeMinutes?: number
+	): Promise<string[]> => {
+		const uniqueIds = [...new Set(notificationIds.filter(Boolean))];
+		if (uniqueIds.length === 0) {
+			return [];
+		}
+
+		const notifications = await this.notificationsRepository.findNotificationsByIds(uniqueIds);
+		if (notifications.length === 0) {
+			return [];
+		}
+
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+		const escalationDecision: MonitorActionDecision = {
+			shouldCreateIncident: false,
+			shouldResolveIncident: false,
+			shouldSendNotification: true,
+			incidentReason: null,
+			notificationReason: reason,
+		};
+		const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, escalationDecision, clientHost);
+
+		const downtimeText = this.formatEscalationDowntimeText(escalationDowntimeMinutes ?? 0);
+		notificationMessage.metadata.isEscalation = true;
+		notificationMessage.metadata.downtimeText = downtimeText;
+
+		if (notificationMessage.type === "monitor_down") {
+			notificationMessage.content.title = `Service Escalation: ${monitor.name} still down`;
+			notificationMessage.content.summary = `Monitor "${monitor.name}" has remained down for ${downtimeText}.`;
+		}
+
+		const outcomes = await Promise.all(
+			notifications.map((notification) => this.send(notification, monitor, monitorStatusResponse, escalationDecision, notificationMessage))
+		);
+
+		const succeededIds = notifications.filter((_, index) => outcomes[index]).map((notification) => notification.id);
+
+		if (succeededIds.length !== notifications.length) {
+			this.logger.warn({
+				message: `Escalation send completed with ${succeededIds.length} success, ${notifications.length - succeededIds.length} failure(s)`,
+				service: SERVICE_NAME,
+				method: "sendEscalationNotifications",
+			});
+		}
+
+		return succeededIds;
+	};
+
+	private formatEscalationDowntimeText = (elapsedMinutes: number): string => {
+		const totalMinutes = Math.max(0, Math.floor(elapsedMinutes));
+		if (totalMinutes < 60) {
+			return `${totalMinutes} minute${totalMinutes === 1 ? "" : "s"}`;
+		}
+
+		const hours = Math.floor(totalMinutes / 60);
+		const minutes = totalMinutes % 60;
+		if (minutes === 0) {
+			return `${hours} hour${hours === 1 ? "" : "s"}`;
+		}
+		return `${hours} hour${hours === 1 ? "" : "s"} ${minutes} minute${minutes === 1 ? "" : "s"}`;
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -16,6 +16,7 @@ export interface Incident {
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;
 	comment?: string | null;
+	escalationChannelsSent?: string[];
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface MonitorEscalation {
+	delayMinutes: number;
+	channelId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +42,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalations?: MonitorEscalation[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/types/notificationMessage.ts
+++ b/server/src/types/notificationMessage.ts
@@ -49,5 +49,7 @@ export interface NotificationMessage {
 	metadata: {
 		teamId: string;
 		notificationReason: string;
+		isEscalation?: boolean;
+		downtimeText?: string;
 	};
 }

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -3,6 +3,11 @@ import { booleanCoercion } from "./shared.js";
 import { GeoContinents } from "@/types/geoCheck.js";
 import { MonitorMatchMethods, MonitorTypes } from "@/types/monitor.js";
 
+const monitorEscalationValidation = z.object({
+	delayMinutes: z.number().int().min(0),
+	channelId: z.string().min(1),
+});
+
 export const getMonitorByIdParamValidation = z.object({
 	monitorId: z.string().min(1, "Monitor ID is required"),
 });
@@ -67,6 +72,7 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalations: z.array(monitorEscalationValidation).default([]),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +95,7 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalations: z.array(monitorEscalationValidation).optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),
@@ -144,6 +151,7 @@ const importedMonitorSchema = z.object({
 	interval: z.number().default(60000),
 	uptimePercentage: z.number().optional(),
 	notifications: z.array(z.string()).default([]),
+	escalations: z.array(monitorEscalationValidation).default([]),
 	secret: z.string().optional(),
 	cpuAlertThreshold: z.number().default(100),
 	cpuAlertCounter: z.number().default(5),


### PR DESCRIPTION
## Describe your changes

Implemented notification escalation support for monitors so alerts can be sent based on incident duration, not only on the initial down event.

## Write your issue number after "Fixes "

Fixes #123 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.
<img width="1270" height="893" alt="Screenshot 2026-04-07 at 5 54 32 PM" src="https://github.com/user-attachments/assets/4b6eec7a-29ff-4e5c-9cae-19bb9e428106" />
