### PR TITLE
feat: implement escalated notifications for monitors

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -83,6 +83,7 @@
 		"node_modules/@babel/core": {
 			"version": "7.29.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -353,6 +354,7 @@
 		"node_modules/@emotion/react": {
 			"version": "11.14.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.13.5",
@@ -390,6 +392,7 @@
 		"node_modules/@emotion/styled": {
 			"version": "11.14.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.13.5",
@@ -1159,6 +1162,7 @@
 		"node_modules/@mui/material": {
 			"version": "7.3.7",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.28.4",
 				"@mui/core-downloads-tracker": "^7.3.7",
@@ -1263,6 +1267,7 @@
 		"node_modules/@mui/system": {
 			"version": "7.3.7",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.28.4",
 				"@mui/private-theming": "^7.3.7",
@@ -2303,6 +2308,7 @@
 			"version": "24.5.2",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.12.0"
 			}
@@ -2318,6 +2324,7 @@
 		"node_modules/@types/react": {
 			"version": "18.3.27",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -2439,6 +2446,7 @@
 			"version": "8.15.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2763,6 +2771,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -3194,7 +3203,8 @@
 		},
 		"node_modules/dayjs": {
 			"version": "1.11.13",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/debug": {
 			"version": "4.4.3",
@@ -3576,6 +3586,7 @@
 			"version": "8.57.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -4320,6 +4331,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.27.6"
 			},
@@ -5103,6 +5115,7 @@
 			"resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.19.0.tgz",
 			"integrity": "sha512-REhYUN8gNP3HlcIZS6QU2uy8iovl31cXsrNDkCcqWSQbCkcpdYLczqDz5PVIwNH42UQNyvukjes/RoHPDrOUmQ==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"@mapbox/geojson-rewind": "^0.5.2",
 				"@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -5750,6 +5763,7 @@
 		"node_modules/react-dom": {
 			"version": "18.3.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -5761,6 +5775,7 @@
 		"node_modules/react-hook-form": {
 			"version": "7.71.1",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18.0.0"
 			},
@@ -5960,7 +5975,8 @@
 		},
 		"node_modules/redux": {
 			"version": "5.0.1",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/redux-persist": {
 			"version": "6.0.0",
@@ -6110,6 +6126,7 @@
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
 			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -6898,6 +6915,7 @@
 			"version": "5.9.3",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -7033,6 +7051,7 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
 			"integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",

--- a/client/src/Components/inputs/EscalationConfig.tsx
+++ b/client/src/Components/inputs/EscalationConfig.tsx
@@ -96,7 +96,7 @@ export const EscalationConfig = <T extends FieldValues>({
 									fieldLabel="Delay (minutes)"
 									type="number"
 									value={value || ""}
-									onChange={onChange}
+									onChange={(e) => onChange(Number((e.target as HTMLInputElement).value))}
 									inputProps={{ min: 1, max: 1440 }}
 									fullWidth
 									size="small"

--- a/client/src/Components/inputs/EscalationConfig.tsx
+++ b/client/src/Components/inputs/EscalationConfig.tsx
@@ -1,0 +1,210 @@
+import { useFieldArray, Controller } from "react-hook-form";
+import type { Control, FieldValues, Path } from "react-hook-form";
+import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import IconButton from "@mui/material/IconButton";
+import { useTheme } from "@mui/material/styles";
+import { Trash2, Plus } from "lucide-react";
+import MenuItem from "@mui/material/MenuItem";
+import type { Notification } from "@/Types/Notification";
+import { TextInput } from "./TextInput";
+import { SelectInput } from "./Select";
+
+interface EscalationConfigProps<T extends FieldValues> {
+	control: Control<T>;
+	fieldName: Path<T>;
+	notifications: Notification[];
+	fieldLabel?: string;
+	maxEscalations?: number;
+}
+
+export const EscalationConfig = <T extends FieldValues>({
+	control,
+	fieldName,
+	notifications,
+	fieldLabel = "Escalation Rules",
+	maxEscalations = 5,
+}: EscalationConfigProps<T>) => {
+	const theme = useTheme();
+	const { fields, append, remove } = useFieldArray({
+		control,
+		name: fieldName as any,
+	});
+
+	const handleAddEscalation = () => {
+		if (fields.length < maxEscalations) {
+			append({
+				delayMinutes: 5,
+				notificationId: notifications[0]?.id || "",
+				isSent: false,
+			} as any);
+		}
+	};
+
+	return (
+		<Stack spacing={theme.spacing(3)}>
+			<Box>
+				<Typography
+					variant="body2"
+					sx={{
+						fontWeight: 600,
+						marginBottom: theme.spacing(2),
+					}}
+				>
+					{fieldLabel}
+				</Typography>
+			</Box>
+
+			{fields.length === 0 ? (
+				<Typography
+					variant="caption"
+					sx={{
+						color: theme.palette.text.secondary,
+						fontStyle: "italic",
+					}}
+				>
+					No escalation rules configured. Add one to start receiving escalated alerts.
+				</Typography>
+			) : null}
+
+			<Stack spacing={theme.spacing(2)}>
+				{fields.map((field, index) => (
+					<Box
+						key={field.id}
+						sx={{
+							display: "grid",
+							gridTemplateColumns: "1fr 1fr auto",
+							gap: theme.spacing(2),
+							alignItems: "flex-end",
+							padding: theme.spacing(2),
+							border: `1px solid ${theme.palette.divider}`,
+							borderRadius: theme.shape.borderRadius,
+							backgroundColor:
+								theme.palette.mode === "dark"
+									? "rgba(255,255,255,0.02)"
+									: "rgba(0,0,0,0.01)",
+						}}
+					>
+						{/* Delay Minutes Input */}
+						<Controller
+							name={`${fieldName}.${index}.delayMinutes` as Path<T>}
+							control={control}
+							render={({ field: { value, onChange } }) => (
+								<TextInput
+									fieldLabel="Delay (minutes)"
+									type="number"
+									value={value || ""}
+									onChange={onChange}
+									inputProps={{ min: 1, max: 1440 }}
+									fullWidth
+									size="small"
+								/>
+							)}
+						/>
+
+						{/* Notification Channel Selector */}
+						<Controller
+							name={`${fieldName}.${index}.notificationId` as Path<T>}
+							control={control}
+							render={({ field: { value, onChange } }) => (
+								<SelectInput
+									value={value || ""}
+									onChange={onChange}
+									displayEmpty
+									fullWidth
+									size="small"
+									placeholder="Select notification channel"
+								>
+									<MenuItem
+										value=""
+										disabled
+									>
+										<Typography sx={{ color: "text.disabled" }}>
+											Select notification channel
+										</Typography>
+									</MenuItem>
+									{notifications.map((notification) => (
+										<MenuItem
+											key={notification.id}
+											value={notification.id}
+										>
+											<Stack
+												direction="row"
+												spacing={1}
+												sx={{ width: "100%" }}
+											>
+												<Typography
+													sx={{
+														textTransform: "capitalize",
+														fontWeight: 500,
+													}}
+												>
+													{notification.type}
+												</Typography>
+												<Typography
+													variant="caption"
+													sx={{
+														color: "text.secondary",
+													}}
+												>
+													{notification.address}
+												</Typography>
+											</Stack>
+										</MenuItem>
+									))}
+								</SelectInput>
+							)}
+						/>
+						<IconButton
+							onClick={() => remove(index)}
+							size="small"
+							sx={{
+								color: theme.palette.error.main,
+								"&:hover": {
+									backgroundColor: "rgba(244, 67, 54, 0.1)",
+								},
+							}}
+							title="Remove escalation rule"
+						>
+							<Trash2 size={18} />
+						</IconButton>
+					</Box>
+				))}
+			</Stack>
+
+			{/* Add Button */}
+			<Box sx={{ display: "flex", justifyContent: "flex-start" }}>
+				<Button
+					variant="outlined"
+					startIcon={<Plus size={18} />}
+					onClick={handleAddEscalation}
+					disabled={fields.length >= maxEscalations}
+					size="small"
+					sx={{
+						textTransform: "none",
+						fontWeight: 500,
+					}}
+				>
+					Add Escalation Rule
+				</Button>
+				{fields.length >= maxEscalations && (
+					<Typography
+						variant="caption"
+						sx={{
+							color: theme.palette.text.secondary,
+							marginLeft: theme.spacing(2),
+							display: "flex",
+							alignItems: "center",
+						}}
+					>
+						Maximum {maxEscalations} escalation rules reached
+					</Typography>
+				)}
+			</Box>
+		</Stack>
+	);
+};
+
+EscalationConfig.displayName = "EscalationConfig";

--- a/client/src/Components/inputs/index.tsx
+++ b/client/src/Components/inputs/index.tsx
@@ -18,3 +18,4 @@ export { DatePickerComponent as DatePicker } from "./DatePicker";
 export { TimePickerComponent as TimePicker } from "./TimePicker";
 export * from "./LanguageSelector";
 export * from "./SwitchTheme";
+export * from "./EscalationConfig";

--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -17,6 +17,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,
 	geoCheckLocations: data?.geoCheckLocations || [],
 	geoCheckInterval: data?.geoCheckInterval || 300000,
+	escalations: data?.escalations || [],
 });
 
 export const useMonitorForm = ({

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -28,6 +28,7 @@ import {
 	SwitchComponent as Switch,
 	SliderWithLabel,
 	Dialog,
+	EscalationConfig,
 } from "@/Components/inputs";
 import { SPACING, LAYOUT } from "@/Utils/Theme/constants";
 import { useGet, usePost, usePatch, useDelete } from "@/Hooks/UseApi";
@@ -761,6 +762,19 @@ const CreateMonitorPage = () => {
 								</Stack>
 							);
 						}}
+					/>
+				}
+			/>
+
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalations.title")}
+				subtitle={t("pages.createMonitor.form.escalations.description")}
+				rightContent={
+					<EscalationConfig
+						control={control}
+						fieldName="escalations"
+						notifications={notifications ?? []}
+						maxEscalations={5}
 					/>
 				}
 			/>

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,13 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface Escalation {
+	id?: string;
+	delayMinutes: number;
+	notificationId: string;
+	isSent: boolean;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -76,6 +83,7 @@ export interface Monitor {
 	geoCheckEnabled?: boolean;
 	geoCheckLocations?: GeoContinent[];
 	geoCheckInterval?: number;
+	escalations?: Escalation[];
 	recentChecks: CheckSnapshot[];
 	createdAt: string;
 	updatedAt: string;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -1,6 +1,16 @@
 import { z } from "zod";
 import { GeoContinents } from "@/Types/GeoCheck";
 
+// Escalation schema
+const escalationSchema = z.object({
+	delayMinutes: z
+		.number()
+		.min(1, "Delay must be at least 1 minute")
+		.max(1440, "Delay must be at most 1440 minutes"),
+	notificationId: z.string().min(1, "Notification channel is required"),
+	isSent: z.boolean().optional(),
+});
+
 // URL schema with custom error message
 const urlSchema = z.url({ message: "Please enter a valid URL" });
 
@@ -27,6 +37,7 @@ const baseSchema = z.object({
 		.number()
 		.min(300000, "Interval must be at least 5 minutes")
 		.optional(),
+	escalations: z.array(escalationSchema).optional(),
 });
 
 // HTTP monitor schema

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -873,6 +873,7 @@
 			"integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.28.6",
 				"@babel/generator": "^7.28.6",
@@ -1502,6 +1503,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -1546,6 +1548,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -4337,6 +4340,7 @@
 			"integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/body-parser": "*",
 				"@types/express-serve-static-core": "^5.0.0",
@@ -4497,6 +4501,7 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
 			"integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -4734,6 +4739,7 @@
 			"integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.56.1",
 				"@typescript-eslint/types": "8.56.1",
@@ -5347,6 +5353,7 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -5925,6 +5932,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.19",
 				"caniuse-lite": "^1.0.30001751",
@@ -6867,6 +6875,7 @@
 			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.1.tgz",
 			"integrity": "sha512-fm4D8ti0dQmFPeF8DXSAA//btEmqCOgAc/9Oa3C1LW94h5usNrJEfrON7b4FkPZgnDEn6OUs5NdxiJZmAtGOpQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssnano-preset-default": "^7.0.9",
 				"lilconfig": "^3.1.3"
@@ -7634,6 +7643,7 @@
 			"integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -7995,6 +8005,7 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
 			"integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
@@ -9639,6 +9650,7 @@
 			"integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/core": "30.2.0",
 				"@jest/types": "30.2.0",
@@ -12509,6 +12521,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -14604,6 +14617,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -14772,6 +14786,7 @@
 			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
@@ -14934,6 +14949,7 @@
 			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -20,6 +20,7 @@ import {
 	InviteService,
 	MaintenanceWindowService,
 	IncidentService,
+	EscalationService,
 	// Notification providers
 	WebhookProvider,
 	SlackProvider,
@@ -46,6 +47,7 @@ import {
 	IIncidentService,
 	INotificationMessageBuilder,
 	ISettingsService,
+	IEscalationService,
 	EnvConfig,
 } from "@/service/index.js";
 
@@ -127,6 +129,7 @@ export type InitializedServices = {
 	maintenanceWindowService: IMaintenanceWindowService;
 	monitorService: IMonitorService;
 	incidentService: IIncidentService;
+	escalationService: IEscalationService;
 	logger: ILogger;
 	notificationsService: INotificationsService;
 	statusPageService: IStatusPageService;
@@ -246,6 +249,8 @@ export const initializeServices = async ({
 		notificationMessageBuilder
 	);
 
+	const escalationService = new EscalationService(logger, notificationsService, monitorsRepository);
+
 	const superSimpleQueueHelper = new SuperSimpleQueueHelper(
 		logger,
 		networkService,
@@ -262,7 +267,8 @@ export const initializeServices = async ({
 		checksRepository,
 		incidentsRepository,
 		geoChecksService,
-		geoChecksRepository
+		geoChecksRepository,
+		escalationService
 	);
 
 	const superSimpleQueue = await SuperSimpleQueue.create(logger, superSimpleQueueHelper, monitorsRepository);
@@ -324,6 +330,7 @@ export const initializeServices = async ({
 		maintenanceWindowService,
 		monitorService,
 		incidentService,
+		escalationService,
 		logger,
 		notificationsService,
 		statusPageService,

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -355,6 +355,24 @@ const MonitorSchema = new Schema<MonitorDocument>(
 			type: [checkSnapshotSchema],
 			default: [],
 		},
+		escalations: [
+			{
+				delayMinutes: {
+					type: Number,
+					required: true,
+				},
+				notificationId: {
+					type: Schema.Types.ObjectId,
+					ref: "Notification",
+					required: true,
+				},
+				isSent: {
+					type: Boolean,
+					default: false,
+				},
+				_id: false,
+			},
+		],
 	},
 	{
 		timestamps: true,

--- a/server/src/repositories/monitors/IMonitorsRepository.ts
+++ b/server/src/repositories/monitors/IMonitorsRepository.ts
@@ -44,4 +44,6 @@ export interface IMonitorsRepository {
 	updateNotifications(teamId: string, monitorIds: string[], notificationIds: string[], action: "add" | "remove" | "set"): Promise<number>;
 	deleteByTeamIdsNotIn(teamIds: string[]): Promise<number>;
 	findAllMonitorIds(): Promise<string[]>;
+	updateEscalationSent(monitorId: string, teamId: string, notificationId: string): Promise<void>;
+	resetEscalations(monitorId: string, teamId: string): Promise<void>;
 }

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -391,6 +391,11 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalations: (doc.escalations ?? []).map((esc: { delayMinutes: number; notificationId: unknown; isSent: boolean }) => ({
+				delayMinutes: esc.delayMinutes,
+				notificationId: toStringId(esc.notificationId),
+				isSent: esc.isSent,
+			})),
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};
@@ -450,6 +455,11 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalations: (doc.escalations ?? []).map((esc: { delayMinutes: number; notificationId: unknown; isSent: boolean }) => ({
+				delayMinutes: esc.delayMinutes,
+				notificationId: toStringId(esc.notificationId),
+				isSent: esc.isSent,
+			})),
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};
@@ -492,6 +502,31 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 	findAllMonitorIds = async (): Promise<string[]> => {
 		const monitors = await MonitorModel.find({}, { _id: 1 }).lean();
 		return monitors.map((doc) => doc._id.toString());
+	};
+
+	updateEscalationSent = async (monitorId: string, teamId: string, notificationId: string): Promise<void> => {
+		await MonitorModel.updateOne(
+			{
+				_id: monitorId,
+				teamId,
+				"escalations.notificationId": new mongoose.Types.ObjectId(notificationId),
+			},
+			{
+				$set: { "escalations.$.isSent": true },
+			}
+		);
+	};
+
+	resetEscalations = async (monitorId: string, teamId: string): Promise<void> => {
+		await MonitorModel.updateOne(
+			{
+				_id: monitorId,
+				teamId,
+			},
+			{
+				$set: { "escalations.$[].isSent": false },
+			}
+		);
 	};
 }
 

--- a/server/src/service/index.ts
+++ b/server/src/service/index.ts
@@ -15,6 +15,7 @@ export * from "@/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.
 export * from "@/service/infrastructure/notificationMessageBuilder.js";
 export * from "@/service/infrastructure/bufferService.js";
 export * from "@/service/infrastructure/emailService.js";
+export * from "@/service/infrastructure/escalationService.js";
 export * from "@/service/infrastructure/globalPingService.js";
 export * from "@/service/infrastructure/networkService.js";
 export * from "@/service/infrastructure/notificationsService.js";

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -10,6 +10,7 @@ import {
 	IStatusService,
 	IncidentService,
 	type IGeoChecksService,
+	type IEscalationService,
 } from "@/service/index.js";
 import { CHECK_TTL_SENTINEL, type MaintenanceWindow, type StatusChangeResult } from "@/types/index.js";
 import {
@@ -66,6 +67,7 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 	private incidentsRepository: IIncidentsRepository;
 	private geoChecksService: IGeoChecksService;
 	private geoChecksRepository: IGeoChecksRepository;
+	private escalationService: IEscalationService;
 
 	constructor(
 		logger: ILogger,
@@ -83,7 +85,8 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 		checksRepository: IChecksRepository,
 		incidentsRepository: IIncidentsRepository,
 		geoChecksService: IGeoChecksService,
-		geoChecksRepository: IGeoChecksRepository
+		geoChecksRepository: IGeoChecksRepository,
+		escalationService: IEscalationService
 	) {
 		this.logger = logger;
 		this.networkService = networkService;
@@ -101,6 +104,7 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 		this.incidentsRepository = incidentsRepository;
 		this.geoChecksService = geoChecksService;
 		this.geoChecksRepository = geoChecksRepository;
+		this.escalationService = escalationService;
 	}
 
 	get serviceName() {
@@ -177,6 +181,31 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 						stack: error instanceof Error ? error.stack : undefined,
 					});
 				});
+				// Step 8. Handle escalations for active incidents (best effort, don't wait)
+				// Check on every run so delayed escalations fire even during ongoing incidents
+				const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitorId, teamId);
+				if (activeIncident) {
+					this.escalationService.processEscalations(statusChangeResult.monitor, activeIncident, status).catch((error: unknown) => {
+						this.logger.warn({
+							message: `Error processing escalations for job ${monitorId}: ${error instanceof Error ? error.message : "Unknown error"}`,
+							service: SERVICE_NAME,
+							method: "getMonitorJob",
+							stack: error instanceof Error ? error.stack : undefined,
+						});
+					});
+				}
+
+				// Step 9. Reset escalations when monitor recovers (best effort, don't wait)
+				if (decision.shouldResolveIncident) {
+					this.escalationService.resetEscalations(monitorId, teamId).catch((error: unknown) => {
+						this.logger.warn({
+							message: `Error resetting escalations for job ${monitorId}: ${error instanceof Error ? error.message : "Unknown error"}`,
+							service: SERVICE_NAME,
+							method: "getMonitorJob",
+							stack: error instanceof Error ? error.stack : undefined,
+						});
+					});
+				}
 			} catch (error: unknown) {
 				this.logger.warn({
 					message: error instanceof Error ? error.message : "Unknown error",

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -172,15 +172,17 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 					});
 				}
 
-				// Step 7. Handle incidents (best effort, don't wait)
-				this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status).catch((error: unknown) => {
+				// Step 7. Handle incidents (wait so incident exists before escalation check)
+				try {
+					await this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status);
+				} catch (error: unknown) {
 					this.logger.warn({
 						message: `Error handling incident for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
 						service: SERVICE_NAME,
 						method: "getMonitorJob",
 						stack: error instanceof Error ? error.stack : undefined,
 					});
-				});
+				}
 				// Step 8. Handle escalations for active incidents (best effort, don't wait)
 				// Check on every run so delayed escalations fire even during ongoing incidents
 				const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitorId, teamId);

--- a/server/src/service/infrastructure/escalationService.ts
+++ b/server/src/service/infrastructure/escalationService.ts
@@ -1,0 +1,118 @@
+import type { Monitor, Escalation } from "@/types/monitor.js";
+import type { Incident } from "@/types/incident.js";
+import type { MonitorStatusResponse } from "@/types/network.js";
+import type { INotificationsService } from "@/service/index.js";
+import type { IMonitorsRepository } from "@/repositories/index.js";
+import type { ILogger } from "@/utils/logger.js";
+
+const SERVICE_NAME = "EscalationService";
+
+export interface IEscalationService {
+	processEscalations(monitor: Monitor, incident: Incident, monitorStatusResponse: MonitorStatusResponse): Promise<Escalation[]>;
+	resetEscalations(monitorId: string, teamId: string): Promise<void>;
+}
+
+export class EscalationService implements IEscalationService {
+	static SERVICE_NAME = SERVICE_NAME;
+
+	private logger: ILogger;
+	private notificationsService: INotificationsService;
+	private monitorsRepository: IMonitorsRepository;
+
+	constructor(logger: ILogger, notificationsService: INotificationsService, monitorsRepository: IMonitorsRepository) {
+		this.logger = logger;
+		this.notificationsService = notificationsService;
+		this.monitorsRepository = monitorsRepository;
+	}
+
+	get serviceName() {
+		return EscalationService.SERVICE_NAME;
+	}
+
+	/**
+	 * Process escalations for a monitor that's currently in an incident
+	 * Checks which escalations should fire based on incident duration
+	 * Sends notifications for escalations that haven't been sent yet
+	 * @param monitor - The monitor with escalations configured
+	 * @param incident - The active incident
+	 * @param monitorStatusResponse - Current monitor status for notification context
+	 * @returns Array of escalations that were processed (sent)
+	 */
+	processEscalations = async (monitor: Monitor, incident: Incident, monitorStatusResponse: MonitorStatusResponse): Promise<Escalation[]> => {
+		const escalations = monitor.escalations || [];
+
+		if (escalations.length === 0) {
+			return [];
+		}
+
+		// Calculate how long the incident has been active (in minutes)
+		const incidentStartTime = new Date(incident.startTime).getTime();
+		const now = Date.now();
+		const incidentDurationMinutes = (now - incidentStartTime) / (60 * 1000);
+
+		const processedEscalations: Escalation[] = [];
+
+		for (const escalation of escalations) {
+			// Skip if already sent
+			if (escalation.isSent) {
+				this.logger.debug({
+					message: `Escalation already sent for monitor ${monitor.id} at ${escalation.delayMinutes} min delay`,
+					service: SERVICE_NAME,
+					method: "processEscalations",
+				});
+				continue;
+			}
+
+			// Check if enough time has passed for this escalation
+			if (incidentDurationMinutes >= escalation.delayMinutes) {
+				try {
+					this.logger.info({
+						message: `Firing escalation for monitor ${monitor.id} after ${escalation.delayMinutes} minutes`,
+						service: SERVICE_NAME,
+						method: "processEscalations",
+					});
+
+					// Send the escalation notification
+					const success = await this.notificationsService.sendEscalationNotification(monitor, escalation.notificationId, monitorStatusResponse);
+
+					if (success) {
+						// Mark escalation as sent only if send succeeded
+						await this.monitorsRepository.updateEscalationSent(monitor.id, monitor.teamId, escalation.notificationId);
+
+						processedEscalations.push(escalation);
+					} else {
+						this.logger.warn({
+							message: `Failed to send escalation for monitor ${monitor.id}, will retry on next check`,
+							service: SERVICE_NAME,
+							method: "processEscalations",
+						});
+					}
+				} catch (error: unknown) {
+					this.logger.error({
+						message: `Failed to process escalation for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+						service: SERVICE_NAME,
+						method: "processEscalations",
+						stack: error instanceof Error ? error.stack : undefined,
+					});
+				}
+			}
+		}
+
+		return processedEscalations;
+	};
+
+	/**
+	 * Reset all escalations for a monitor (set isSent flag to false)
+	 * Called when a monitor recovers from an incident
+	 * @param monitorId - The monitor ID
+	 * @param teamId - The team ID
+	 */
+	resetEscalations = async (monitorId: string, teamId: string): Promise<void> => {
+		await this.monitorsRepository.resetEscalations(monitorId, teamId);
+		this.logger.info({
+			message: `Reset escalations for monitor ${monitorId}`,
+			service: SERVICE_NAME,
+			method: "resetEscalations",
+		});
+	};
+}

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,7 +14,7 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
-
+	sendEscalationNotification: (monitor: Monitor, notificationId: string, monitorStatusResponse: MonitorStatusResponse) => Promise<boolean>;
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
 }
@@ -139,6 +139,56 @@ export class NotificationsService implements INotificationsService {
 
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	sendEscalationNotification = async (monitor: Monitor, notificationId: string, monitorStatusResponse: MonitorStatusResponse): Promise<boolean> => {
+		try {
+			// Fetch the specific notification
+			const notification = await this.notificationsRepository.findById(notificationId, monitor.teamId);
+			if (!notification) {
+				this.logger.warn({
+					message: `Notification ${notificationId} not found for escalation`,
+					service: SERVICE_NAME,
+					method: "sendEscalationNotification",
+				});
+				return false;
+			}
+
+			// Build escalation decision object
+			const escalationDecision: MonitorActionDecision = {
+				shouldSendNotification: true,
+				shouldCreateIncident: false,
+				shouldResolveIncident: false,
+				incidentReason: null,
+				notificationReason: "escalation",
+			};
+
+			// Build escalation message
+			const settings = this.settingsService.getSettings();
+			const clientHost = settings.clientHost || "Host not defined";
+			const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, escalationDecision, clientHost);
+
+			// Send single notification
+			const success = await this.send(notification, monitor, monitorStatusResponse, escalationDecision, notificationMessage);
+
+			if (!success) {
+				this.logger.warn({
+					message: `Failed to send escalation notification ${notificationId} for monitor ${monitor.id}`,
+					service: SERVICE_NAME,
+					method: "sendEscalationNotification",
+				});
+			}
+
+			return success;
+		} catch (error: unknown) {
+			this.logger.error({
+				message: `Error sending escalation notification: ${error instanceof Error ? error.message : "Unknown error"}`,
+				service: SERVICE_NAME,
+				method: "sendEscalationNotification",
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+			return false;
+		}
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -54,8 +54,16 @@ export interface Monitor {
 	geoCheckLocations?: GeoContinent[];
 	geoCheckInterval?: number;
 	recentChecks: CheckSnapshot[];
+	escalations?: Escalation[];
 	createdAt: string;
 	updatedAt: string;
+}
+
+export interface Escalation {
+	id?: string;
+	delayMinutes: number;
+	notificationId: string;
+	isSent: boolean;
 }
 
 export interface MonitorsSummary {

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -78,6 +78,15 @@ export const createMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalations: z
+		.array(
+			z.object({
+				delayMinutes: z.number().min(1).max(1440),
+				notificationId: z.string().min(1),
+				isSent: z.boolean().optional(),
+			})
+		)
+		.optional(),
 });
 
 export const editMonitorBodyValidation = z.object({
@@ -107,6 +116,15 @@ export const editMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalations: z
+		.array(
+			z.object({
+				delayMinutes: z.number().min(1).max(1440),
+				notificationId: z.string().min(1),
+				isSent: z.boolean().optional(),
+			})
+		)
+		.optional(),
 });
 
 export const pauseMonitorParamValidation = z.object({


### PR DESCRIPTION
## Escalated Notifications

Implements escalated notifications for monitors and fires different alert channels based on how long an incident has been active.

**Frontend**
- Built a new EscalationConfig component that lets you add rows of escalation rules and each row has a delay (in minutes) and a notification channel selector
- Added it to the Create Monitor form so it saves with the rest of the monitor settings
- Added the escalations field to the Monitor type and validation schema

**Backend**
- Added an escalations array to the Monitor schema with delayMinutes, notificationId, and isSent fields
- Built an EscalationService that runs on every monitor check, calculates how long the 
  incident has been active, and fires any escalations whose delay has passed
- Escalations are marked as sent so they don't spam and reset when the monitor recovers
- Wired everything into the heartbeat job and notification service

