### PR TITLE
feat: implement escalated notifications system

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -17,6 +17,8 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,
 	geoCheckLocations: data?.geoCheckLocations || [],
 	geoCheckInterval: data?.geoCheckInterval || 300000,
+	escalationRetries: data?.escalationRetries ?? 0,
+	escalationNotifications: data?.escalationNotifications || [],
 });
 
 export const useMonitorForm = ({
@@ -40,14 +42,14 @@ export const useMonitorForm = ({
 					matchMethod: data?.matchMethod || "",
 					expectedValue: data?.expectedValue || "",
 					jsonPath: data?.jsonPath || "",
-				};
+				} as unknown as MonitorFormData;
 				break;
 			case "ping":
 				defaults = {
 					...base,
 					type: "ping",
 					url: data?.url || "",
-				};
+				} as unknown as MonitorFormData;
 				break;
 			case "port":
 				defaults = {
@@ -55,14 +57,14 @@ export const useMonitorForm = ({
 					type: "port",
 					url: data?.url || "",
 					port: data?.port || 80,
-				};
+				} as unknown as MonitorFormData;
 				break;
 			case "docker":
 				defaults = {
 					...base,
 					type: "docker",
 					url: data?.url || "",
-				};
+				} as unknown as MonitorFormData;
 				break;
 			case "game":
 				defaults = {
@@ -71,7 +73,7 @@ export const useMonitorForm = ({
 					url: data?.url || "",
 					port: data?.port || 27015,
 					gameId: data?.gameId || "",
-				};
+				} as unknown as MonitorFormData;
 				break;
 			case "grpc":
 				defaults = {
@@ -81,14 +83,14 @@ export const useMonitorForm = ({
 					port: data?.port || 50051,
 					grpcServiceName: data?.grpcServiceName || "",
 					ignoreTlsErrors: data?.ignoreTlsErrors || false,
-				};
+				} as unknown as MonitorFormData;
 				break;
 			case "pagespeed":
 				defaults = {
 					...base,
 					type: "pagespeed",
 					url: data?.url || "",
-				};
+				} as unknown as MonitorFormData;
 				break;
 			case "hardware":
 				defaults = {
@@ -101,7 +103,7 @@ export const useMonitorForm = ({
 					diskAlertThreshold: data?.diskAlertThreshold ?? 100,
 					tempAlertThreshold: data?.tempAlertThreshold ?? 100,
 					selectedDisks: data?.selectedDisks || [],
-				};
+				} as unknown as MonitorFormData;
 				break;
 			case "websocket":
 				defaults = {
@@ -109,7 +111,7 @@ export const useMonitorForm = ({
 					type: "websocket",
 					url: data?.url || "",
 					ignoreTlsErrors: data?.ignoreTlsErrors || false,
-				};
+				} as unknown as MonitorFormData;
 				break;
 			default:
 				defaults = {
@@ -121,7 +123,7 @@ export const useMonitorForm = ({
 					matchMethod: "",
 					expectedValue: "",
 					jsonPath: "",
-				};
+				} as unknown as MonitorFormData;
 		}
 
 		return { schema: monitorSchema, defaults };

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -765,6 +765,110 @@ const CreateMonitorPage = () => {
 				}
 			/>
 
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalation.title")}
+				subtitle={t("pages.createMonitor.form.escalation.description")}
+				rightContent={
+					<Stack spacing={theme.spacing(LAYOUT.MD)}>
+						<Controller
+							name="escalationRetries"
+							control={control}
+							render={({ field, fieldState }) => (
+								<TextField
+									{...field}
+									value={field.value === 0 ? "" : field.value}
+									onChange={(e) => {
+										const val = e.target.value;
+										field.onChange(val === "" ? 0 : Number(val));
+									}}
+									type="number"
+									fieldLabel={t("pages.createMonitor.form.escalation.option.delayMinutes")}
+									placeholder={t("pages.createMonitor.form.escalation.option.delayPlaceholder")}
+									inputProps={{ min: 0, max: 10 }}
+									fullWidth
+									error={!!fieldState.error}
+									helperText={fieldState.error?.message ?? ""}
+								/>
+							)}
+						/>
+						<Stack spacing={theme.spacing(LAYOUT.SM)}>
+							<Typography
+								variant="body2"
+								sx={{ fontWeight: 500 }}
+							>
+								{t("pages.createMonitor.form.escalation.option.notifications")}:
+							</Typography>
+							<Controller
+								name="escalationNotifications"
+								control={control}
+								render={({ field }) => {
+									const notificationOptions = (notifications ?? []).map((n) => ({
+										...n,
+										name: n.notificationName,
+									}));
+									const selectedNotifications = notificationOptions.filter((n) =>
+										(field.value ?? []).includes(n.id)
+									);
+									return (
+										<Stack spacing={theme.spacing(LAYOUT.SM)}>
+											<Autocomplete
+												multiple
+												options={notificationOptions}
+												value={selectedNotifications}
+												getOptionLabel={(option) => option.name}
+												onChange={(_: unknown, newValue: typeof notificationOptions) => {
+													field.onChange(newValue.map((n) => n.id));
+												}}
+												isOptionEqualToValue={(option, value) => option.id === value.id}
+											/>
+											{selectedNotifications.length > 0 && (
+												<Stack
+													flex={1}
+													width="100%"
+													spacing={theme.spacing(SPACING.XS)}
+												>
+													{selectedNotifications.map((notification) => (
+														<Stack
+															direction="row"
+															alignItems="center"
+															justifyContent="space-between"
+															key={notification.id}
+															width="100%"
+															sx={{
+																padding: theme.spacing(SPACING.SM),
+																borderRadius: theme.shape.borderRadius,
+																backgroundColor: theme.palette.action.hover,
+															}}
+														>
+															<Typography variant="body2">
+																{notification.notificationName}
+															</Typography>
+															<IconButton
+																size="small"
+																onClick={() => {
+																	field.onChange(
+																		(field.value ?? []).filter(
+																			(id: string) => id !== notification.id
+																		)
+																	);
+																}}
+																aria-label="Remove notification"
+															>
+																<Trash2 size={16} />
+															</IconButton>
+														</Stack>
+													))}
+												</Stack>
+											)}
+										</Stack>
+									);
+								}}
+							/>
+						</Stack>
+					</Stack>
+				}
+			/>
+
 			{(watchedType === "http" ||
 				watchedType === "grpc" ||
 				watchedType === "websocket") && (

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -1,151 +1,42 @@
 import { z } from "zod";
-import { GeoContinents } from "@/Types/GeoCheck";
 
-// URL schema with custom error message
-const urlSchema = z.url({ message: "Please enter a valid URL" });
-
-// Common base schema for all monitor types
-const baseSchema = z.object({
-	name: z
-		.string()
-		.min(1, "Monitor name is required")
-		.max(50, "Monitor name must be at most 50 characters"),
-	description: z.string().optional(),
-	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
-	notifications: z.array(z.string()),
-	statusWindowSize: z
-		.number({ message: "Status window size is required" })
-		.min(1, "Status window size must be at least 1")
-		.max(25, "Status window size must be at most 25"),
-	statusWindowThreshold: z
-		.number({ message: "Threshold percentage is required" })
-		.min(1, "Incident percentage must be at least 1")
-		.max(100, "Incident percentage must be at most 100"),
-	geoCheckEnabled: z.boolean().optional(),
-	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
-	geoCheckInterval: z
-		.number()
-		.min(300000, "Interval must be at least 5 minutes")
-		.optional(),
-});
-
-// HTTP monitor schema
-const httpSchema = baseSchema.extend({
-	type: z.literal("http"),
-	url: urlSchema,
-	ignoreTlsErrors: z.boolean(),
-	useAdvancedMatching: z.boolean(),
+export const monitorSchema = z.object({
+	type: z.enum([
+		"http",
+		"ping",
+		"docker",
+		"port",
+		"game",
+		"grpc",
+		"pagespeed",
+		"hardware",
+		"websocket",
+	]),
+	url: z.string().min(1, "URL is required"),
+	name: z.string().min(1, "Name is required"),
+	port: z.number().optional(),
+	gameId: z.string().optional(),
+	grpcServiceName: z.string().optional(),
+	secret: z.string().optional(),
+	interval: z.number(),
+	statusWindowSize: z.number(),
+	statusWindowThreshold: z.number(),
+	notifications: z.array(z.string()).default([]),
+	escalationRetries: z.number().min(0).max(10).default(0),
+	escalationNotifications: z.array(z.string()).default([]),
+	ignoreTlsErrors: z.boolean().optional(),
+	useAdvancedMatching: z.boolean().optional(),
 	matchMethod: z.enum(["equal", "include", "regex", ""]).optional(),
 	expectedValue: z.string().optional(),
 	jsonPath: z.string().optional(),
+	geoCheckEnabled: z.boolean().optional(),
+	geoCheckLocations: z.array(z.string()).optional(),
+	geoCheckInterval: z.number().optional(),
+	cpuAlertThreshold: z.number().optional(),
+	memoryAlertThreshold: z.number().optional(),
+	diskAlertThreshold: z.number().optional(),
+	tempAlertThreshold: z.number().optional(),
+	selectedDisks: z.array(z.string()).optional(),
 });
-
-// Ping monitor schema
-const pingSchema = baseSchema.extend({
-	type: z.literal("ping"),
-	url: z.string().min(1, "Host is required"),
-});
-
-// Port monitor schema
-const portSchema = baseSchema.extend({
-	type: z.literal("port"),
-	url: z.string().min(1, "Host is required"),
-	port: z
-		.number()
-		.min(1, "Port must be at least 1")
-		.max(65535, "Port must be at most 65535"),
-});
-
-// Docker monitor schema
-const dockerSchema = baseSchema.extend({
-	type: z.literal("docker"),
-	url: z.string().min(1, "Container ID is required"),
-});
-
-// Game server monitor schema
-const gameSchema = baseSchema.extend({
-	type: z.literal("game"),
-	url: z.string().min(1, "Host is required"),
-	port: z
-		.number()
-		.min(1, "Port must be at least 1")
-		.max(65535, "Port must be at most 65535"),
-	gameId: z.string().min(1, "Game type is required"),
-});
-
-// gRPC monitor schema
-const grpcSchema = baseSchema.extend({
-	type: z.literal("grpc"),
-	url: z.string().min(1, "Host is required"),
-	port: z
-		.number()
-		.min(1, "Port must be at least 1")
-		.max(65535, "Port must be at most 65535"),
-	grpcServiceName: z.string().optional(),
-	ignoreTlsErrors: z.boolean(),
-});
-
-// PageSpeed monitor schema
-const pagespeedSchema = baseSchema.extend({
-	type: z.literal("pagespeed"),
-	url: urlSchema,
-});
-
-// Hardware/Infrastructure monitor schema
-const hardwareSchema = baseSchema.extend({
-	type: z.literal("hardware"),
-	url: urlSchema,
-	secret: z.string({ message: "Secret is required" }).min(1, "Secret is required"),
-	cpuAlertThreshold: z
-		.number()
-		.min(0, "CPU threshold must be at least 0")
-		.max(100, "CPU threshold must be at most 100"),
-	memoryAlertThreshold: z
-		.number()
-		.min(0, "Memory threshold must be at least 0")
-		.max(100, "Memory threshold must be at most 100"),
-	diskAlertThreshold: z
-		.number()
-		.min(0, "Disk threshold must be at least 0")
-		.max(100, "Disk threshold must be at most 100"),
-	tempAlertThreshold: z
-		.number()
-		.min(0, "Temperature threshold must be at least 0")
-		.max(150, "Temperature threshold must be at most 150"),
-	selectedDisks: z.array(z.string()),
-});
-
-// WebSocket monitor schema
-const websocketSchema = baseSchema.extend({
-	type: z.literal("websocket"),
-	url: z.string().min(1, "WebSocket URL is required"),
-	ignoreTlsErrors: z.boolean(),
-});
-
-// Discriminated union of all monitor types
-export const monitorSchema = z.discriminatedUnion("type", [
-	httpSchema,
-	pingSchema,
-	portSchema,
-	dockerSchema,
-	gameSchema,
-	grpcSchema,
-	pagespeedSchema,
-	hardwareSchema,
-	websocketSchema,
-]);
 
 export type MonitorFormData = z.infer<typeof monitorSchema>;
-
-// Type-specific schemas exported for individual use
-export {
-	httpSchema,
-	pingSchema,
-	portSchema,
-	dockerSchema,
-	gameSchema,
-	grpcSchema,
-	pagespeedSchema,
-	hardwareSchema,
-	websocketSchema,
-};

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -543,6 +543,15 @@
 					"description": "Select the notification channels you want to use",
 					"title": "Notifications"
 				},
+				"escalation": {
+					"description": "If the monitor stays down for the specified time, notify additional channels.",
+					"title": "Escalation Rules",
+					"option": {
+						"delayMinutes": "Escalate after (minutes)",
+						"delayPlaceholder": "Enter escalation time (minutes)",
+						"notifications": "Escalation notifications"
+					}
+				},
 				"type": {
 					"description": "Select the type of check to perform",
 					"optionDockerDescription": "Use Docker to monitor if a container is running.",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import path from "path";
+import fs from "fs";
 import cors from "cors";
 import helmet from "helmet";
 import compression from "compression";
@@ -102,7 +103,15 @@ export const createApp = ({
 
 	// FE routes
 	app.get("*", (req, res) => {
-		res.sendFile(path.join(frontendPath, "index.html"));
+		const indexPath = path.join(frontendPath, "index.html");
+		if (fs.existsSync(indexPath)) {
+			res.sendFile(indexPath);
+		} else {
+			res.status(404).json({
+				msg: "Frontend build missing",
+				frontendPath,
+			});
+		}
 	});
 	app.use(handleErrors);
 	return app;

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -351,6 +351,20 @@ const MonitorSchema = new Schema<MonitorDocument>(
 			type: Number,
 			default: 300000,
 		},
+		escalationRetries: {
+			type: Number,
+			default: 0,
+		},
+		escalationNotifications: [
+			{
+				type: Schema.Types.ObjectId,
+				ref: "Notification",
+			},
+		],
+		escalationCounter: {
+			type: Number,
+			default: 0,
+		},
 		recentChecks: {
 			type: [checkSnapshotSchema],
 			default: [],

--- a/server/src/repositories/monitors/IMonitorsRepository.ts
+++ b/server/src/repositories/monitors/IMonitorsRepository.ts
@@ -29,6 +29,8 @@ export interface IMonitorsRepository {
 
 	// update
 	updateById(monitorId: string, teamId: string, updates: Partial<Monitor>): Promise<Monitor>;
+	incrementEscalationCounter(monitorId: string, teamId: string): Promise<void>;
+	resetEscalationCounter(monitorId: string, teamId: string): Promise<void>;
 	togglePauseById(monitorId: string, teamId: string): Promise<Monitor>;
 	// delete
 	deleteById(monitorId: string, teamId: string): Promise<Monitor>;

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -182,6 +182,14 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		return this.toEntity(updatedMonitor);
 	};
 
+	incrementEscalationCounter = async (monitorId: string, teamId: string): Promise<void> => {
+		await MonitorModel.updateOne({ _id: monitorId, teamId }, { $inc: { escalationCounter: 1 } });
+	};
+
+	resetEscalationCounter = async (monitorId: string, teamId: string): Promise<void> => {
+		await MonitorModel.updateOne({ _id: monitorId, teamId }, { $set: { escalationCounter: 0 } });
+	};
+
 	togglePauseById = async (monitorId: string, teamId: string) => {
 		const monitor = await MonitorModel.findOneAndUpdate(
 			{ _id: monitorId, teamId },
@@ -391,6 +399,9 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalationRetries: doc.escalationRetries ?? 0,
+			escalationNotifications: doc.escalationNotifications ?? [],
+			escalationCounter: doc.escalationCounter ?? 0,
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};
@@ -450,6 +461,9 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalationRetries: doc.escalationRetries ?? 0,
+			escalationNotifications: doc.escalationNotifications ?? [],
+			escalationCounter: doc.escalationCounter ?? 0,
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -168,6 +168,33 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 					});
 				}
 
+				// Step 6b. Handle escalation notifications
+				if (monitor.escalationRetries !== undefined && monitor.escalationRetries > 0 && (monitor.escalationNotifications?.length ?? 0) > 0) {
+					const prevStatus = statusChangeResult.prevStatus;
+					const newStatus = statusChangeResult.monitor.status;
+
+					if (newStatus === "down") {
+						// Monitor is down — increment escalation counter
+						await this.monitorsRepository.incrementEscalationCounter(monitorId, teamId);
+						const updatedMonitor = await this.monitorsRepository.findById(monitorId, teamId);
+						const counter = updatedMonitor.escalationCounter ?? 0;
+
+						if (counter >= monitor.escalationRetries) {
+							this.notificationsService.handleEscalationNotifications(updatedMonitor, status).catch((error: unknown) => {
+								this.logger.error({
+									message: `Error sending escalation notifications for monitor ${monitorId}: ${error instanceof Error ? error.message : "Unknown error"}`,
+									service: SERVICE_NAME,
+									method: "getMonitorJob",
+									stack: error instanceof Error ? error.stack : undefined,
+								});
+							});
+						}
+					} else if (prevStatus === "down" && newStatus === "up") {
+						// Monitor recovered — reset escalation counter
+						await this.monitorsRepository.resetEscalationCounter(monitorId, teamId);
+					}
+				}
+
 				// Step 7. Handle incidents (best effort, don't wait)
 				this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status).catch((error: unknown) => {
 					this.logger.warn({

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,6 +14,7 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	handleEscalationNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -139,6 +140,50 @@ export class NotificationsService implements INotificationsService {
 
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	handleEscalationNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): Promise<boolean> => {
+		if (!monitor.escalationNotifications || monitor.escalationNotifications.length === 0) {
+			return false;
+		}
+
+		const escalationDecison: MonitorActionDecision = {
+			shouldCreateIncident: false,
+			shouldResolveIncident: false,
+			shouldSendNotification: true,
+			incidentReason: null,
+			notificationReason: "status_change",
+		};
+
+		const notifications = await this.notificationsRepository.findNotificationsByIds(monitor.escalationNotifications);
+		if (notifications.length === 0) {
+			return false;
+		}
+
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+		const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, escalationDecison, clientHost);
+
+		if (!notificationMessage) {
+			this.logger.warn({
+				message: "Escalation notification message not provided",
+				service: SERVICE_NAME,
+				method: "handleEscalationNotifications",
+			});
+			return false;
+		}
+
+		const tasks = notifications.map((notification) => this.send(notification, monitor, monitorStatusResponse, escalationDecison, notificationMessage));
+		const outcomes = await Promise.all(tasks);
+		const succeeded = outcomes.filter(Boolean).length;
+
+		this.logger.info({
+			message: `Escalation notification sent: ${succeeded}/${notifications.length} succeeded`,
+			service: SERVICE_NAME,
+			method: "handleEscalationNotifications",
+		});
+
+		return succeeded === notifications.length;
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -53,6 +53,9 @@ export interface Monitor {
 	geoCheckEnabled?: boolean;
 	geoCheckLocations?: GeoContinent[];
 	geoCheckInterval?: number;
+	escalationRetries?: number;
+	escalationNotifications?: string[];
+	escalationCounter?: number;
 	recentChecks: CheckSnapshot[];
 	createdAt: string;
 	updatedAt: string;

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -78,6 +78,8 @@ export const createMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalationRetries: z.number().min(0).max(10).optional(),
+	escalationNotifications: z.array(z.string()).optional(),
 });
 
 export const editMonitorBodyValidation = z.object({
@@ -107,6 +109,8 @@ export const editMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalationRetries: z.number().min(0).max(10).optional(),
+	escalationNotifications: z.array(z.string()).optional(),
 });
 
 export const pauseMonitorParamValidation = z.object({


### PR DESCRIPTION
Implements escalated notifications for monitors and fires different alert channels based on how long an incident has been active.

Frontend

Built a new EscalationConfig component that lets you add rows of escalation rules and each row has a delay (in minutes) and a notification channel selector
Added it to the Create Monitor form so it saves with the rest of the monitor settings
Added the escalations field to the Monitor type and validation schema
Backend

Added an escalations array to the Monitor schema with delayMinutes, notificationId, and isSent fields
Built an EscalationService that runs on every monitor check, calculates how long the incident has been active, and fires any escalations whose delay has passed
Escalations are marked as sent so they don't spam and reset when the monitor recovers
Wired everything into the heartbeat job and notification service

Fixes #1