### PR TITLE
Escalated Notifications

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -17,6 +17,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,
 	geoCheckLocations: data?.geoCheckLocations || [],
 	geoCheckInterval: data?.geoCheckInterval || 300000,
+	escalationRules: data?.escalationRules || { afterMinutes: 0, notificationIds: [] },
 });
 
 export const useMonitorForm = ({

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -212,6 +212,10 @@ const CreateMonitorPage = () => {
 
 	const watchedUseAdvancedMatching = watch("useAdvancedMatching") as boolean;
 	const watchGeoCheckEnabled = watch("geoCheckEnabled") as boolean;
+	const escalationNotificationOptions = useMemo(
+		() => (notifications ?? []).map((n) => ({ ...n, name: n.notificationName })),
+		[notifications]
+	);
 
 	useEffect(() => {
 		clearErrors();
@@ -762,6 +766,82 @@ const CreateMonitorPage = () => {
 							);
 						}}
 					/>
+				}
+			/>
+
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalation.title")}
+				subtitle={t("pages.createMonitor.form.escalation.description")}
+				rightContent={
+					<>
+						<Controller
+							name="escalationRules.afterMinutes"
+							control={control}
+							render={({ field, fieldState }) => (
+								<TextField
+									type="number"
+									value={field.value ?? 0}
+									onChange={(e) => field.onChange(e.target.value === "" ? 0 : Number(e.target.value))}
+									fieldLabel={t("pages.createMonitor.form.escalation.option.afterMinutes.label")}
+									placeholder={t("pages.createMonitor.form.escalation.option.afterMinutes.placeholder")}
+									fullWidth
+									error={!!fieldState.error}
+									helperText={fieldState.error?.message ?? ""}
+								/>
+							)}
+						/>
+						<Controller
+							name="escalationRules.notificationIds"
+							control={control}
+							render={({ field, fieldState }) => {
+								const selectedNotifications = escalationNotificationOptions.filter((n) =>
+									(field.value ?? []).includes(n.id)
+								);
+
+								return (
+									<Stack spacing={theme.spacing(LAYOUT.MD)}>
+										<Autocomplete
+											multiple
+											options={escalationNotificationOptions}
+											value={selectedNotifications}
+											getOptionLabel={(option) => option.name}
+											onChange={(_: unknown, newValue: typeof escalationNotificationOptions) => {
+												field.onChange(newValue.map((n) => n.id));
+											}}
+											isOptionEqualToValue={(option, value) => option.id === value.id}
+											fieldLabel={t("pages.createMonitor.form.escalation.option.notificationIds.label")}
+										/>
+										{fieldState.error?.message && (
+											<Typography color="error" variant="body2">
+												{fieldState.error.message}
+											</Typography>
+										)}
+										{selectedNotifications.length > 0 && (
+											<Stack flex={1} width="100%">
+												{selectedNotifications.map((notification, index) => (
+													<Stack direction="row" alignItems="center" key={notification.id} width="100%">
+														<Typography flexGrow={1}>{notification.notificationName}</Typography>
+														<IconButton
+															size="small"
+															onClick={() => {
+																field.onChange(
+																	(field.value ?? []).filter((id: string) => id !== notification.id)
+																);
+															}}
+															aria-label="Remove escalation notification"
+														>
+															<Trash2 size={16} />
+														</IconButton>
+														{index < selectedNotifications.length - 1 && <Divider />}
+													</Stack>
+												))}
+											</Stack>
+										)}
+									</Stack>
+								);
+							}}
+						/>
+					</>
 				}
 			/>
 

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -781,9 +781,15 @@ const CreateMonitorPage = () => {
 								<TextField
 									type="number"
 									value={field.value ?? 0}
-									onChange={(e) => field.onChange(e.target.value === "" ? 0 : Number(e.target.value))}
-									fieldLabel={t("pages.createMonitor.form.escalation.option.afterMinutes.label")}
-									placeholder={t("pages.createMonitor.form.escalation.option.afterMinutes.placeholder")}
+									onChange={(e) =>
+										field.onChange(e.target.value === "" ? 0 : Number(e.target.value))
+									}
+									fieldLabel={t(
+										"pages.createMonitor.form.escalation.option.afterMinutes.label"
+									)}
+									placeholder={t(
+										"pages.createMonitor.form.escalation.option.afterMinutes.placeholder"
+									)}
 									fullWidth
 									error={!!fieldState.error}
 									helperText={fieldState.error?.message ?? ""}
@@ -805,27 +811,47 @@ const CreateMonitorPage = () => {
 											options={escalationNotificationOptions}
 											value={selectedNotifications}
 											getOptionLabel={(option) => option.name}
-											onChange={(_: unknown, newValue: typeof escalationNotificationOptions) => {
+											onChange={(
+												_: unknown,
+												newValue: typeof escalationNotificationOptions
+											) => {
 												field.onChange(newValue.map((n) => n.id));
 											}}
 											isOptionEqualToValue={(option, value) => option.id === value.id}
-											fieldLabel={t("pages.createMonitor.form.escalation.option.notificationIds.label")}
+											fieldLabel={t(
+												"pages.createMonitor.form.escalation.option.notificationIds.label"
+											)}
 										/>
 										{fieldState.error?.message && (
-											<Typography color="error" variant="body2">
+											<Typography
+												color="error"
+												variant="body2"
+											>
 												{fieldState.error.message}
 											</Typography>
 										)}
 										{selectedNotifications.length > 0 && (
-											<Stack flex={1} width="100%">
+											<Stack
+												flex={1}
+												width="100%"
+											>
 												{selectedNotifications.map((notification, index) => (
-													<Stack direction="row" alignItems="center" key={notification.id} width="100%">
-														<Typography flexGrow={1}>{notification.notificationName}</Typography>
+													<Stack
+														direction="row"
+														alignItems="center"
+														key={notification.id}
+														width="100%"
+													>
+														<Typography flexGrow={1}>
+															{notification.notificationName}
+														</Typography>
 														<IconButton
 															size="small"
 															onClick={() => {
 																field.onChange(
-																	(field.value ?? []).filter((id: string) => id !== notification.id)
+																	(field.value ?? []).filter(
+																		(id: string) => id !== notification.id
+																	)
 																);
 															}}
 															aria-label="Remove escalation notification"

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface EscalationRule {
+	afterMinutes: number;
+	notificationIds: string[];
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -79,6 +84,7 @@ export interface Monitor {
 	recentChecks: CheckSnapshot[];
 	createdAt: string;
 	updatedAt: string;
+	escalationRules?: EscalationRule;
 }
 
 export type MonitorWithChecks = Monitor;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -27,6 +27,12 @@ const baseSchema = z.object({
 		.number()
 		.min(300000, "Interval must be at least 5 minutes")
 		.optional(),
+	escalationRules: z
+		.object({
+			afterMinutes: z.number().min(0, "Escalation threshold must be at least 0 minutes"),
+			notificationIds: z.array(z.string()).min(1, "At least one notification channel is required"),
+		})
+		.optional(),
 });
 
 // HTTP monitor schema

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -30,7 +30,9 @@ const baseSchema = z.object({
 	escalationRules: z
 		.object({
 			afterMinutes: z.number().min(0, "Escalation threshold must be at least 0 minutes"),
-			notificationIds: z.array(z.string()).min(1, "At least one notification channel is required"),
+			notificationIds: z
+				.array(z.string())
+				.min(1, "At least one notification channel is required"),
 		})
 		.optional(),
 });

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -543,6 +543,21 @@
 					"description": "Select the notification channels you want to use",
 					"title": "Notifications"
 				},
+				"escalation": {
+					"title": "Escalation rules",
+					"description": "If the monitor stays down for the specified time, notify additional channels.",
+					"option": {
+						"afterMinutes": {
+							"label": "Escalate after (minutes)",
+							"placeholder": "0"
+						},
+						"notificationIds": {
+							"label": "Escalation notification channels",
+							"placeholder": "Type to search",
+							"helper": "Choose one or more existing notifications"
+						}
+					}
+				},
 				"type": {
 					"description": "Select the type of check to perform",
 					"optionDockerDescription": "Use Docker to monitor if a container is running.",

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -9,6 +9,8 @@ type IncidentDocumentBase = Omit<Incident, "id" | "monitorId" | "teamId" | "reso
 	endTime: Date | null;
 	createdAt: Date;
 	updatedAt: Date;
+	escalationSent: boolean;
+	
 };
 
 export interface IncidentDocument extends IncidentDocumentBase {
@@ -71,6 +73,10 @@ const IncidentSchema = new Schema<IncidentDocument>(
 		comment: {
 			type: String,
 			default: null,
+		},
+		escalationSent: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	{ timestamps: true }

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -10,7 +10,6 @@ type IncidentDocumentBase = Omit<Incident, "id" | "monitorId" | "teamId" | "reso
 	createdAt: Date;
 	updatedAt: Date;
 	escalationSent: boolean;
-	
 };
 
 export interface IncidentDocument extends IncidentDocumentBase {

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -16,15 +16,21 @@ import type {
 
 type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Date };
 
+type EscalationRuleDocument = {
+	afterMinutes: number;
+	notificationIds: string[];
+};
+
 type MonitorDocumentBase = Omit<
 	Monitor,
-	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
+	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt" | "escalationRules"
 > & {
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
 	selectedDisks: string[];
 	matchMethod?: MonitorMatchMethod;
+	escalationRules?: EscalationRuleDocument;
 };
 
 interface MonitorDocument extends MonitorDocumentBase {
@@ -45,6 +51,14 @@ const snapshotTimingPhasesSchema = new Schema<GotTimings["phases"]>(
 		firstByte: { type: Number },
 		download: { type: Number },
 		total: { type: Number },
+	},
+	{ _id: false }
+);
+
+const escalationRuleSchema = new Schema<EscalationRuleDocument>(
+	{
+		afterMinutes: { type: Number, required: true },
+		notificationIds: { type: [String], default: [] },
 	},
 	{ _id: false }
 );
@@ -354,6 +368,10 @@ const MonitorSchema = new Schema<MonitorDocument>(
 		recentChecks: {
 			type: [checkSnapshotSchema],
 			default: [],
+		},
+		escalationRules: {
+			type: escalationRuleSchema,
+			default: undefined,
 		},
 	},
 	{

--- a/server/src/repositories/incidents/MongoIncidentRepository.ts
+++ b/server/src/repositories/incidents/MongoIncidentRepository.ts
@@ -60,6 +60,7 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			resolvedBy: doc.resolvedBy ? this.toStringId(doc.resolvedBy) : null,
 			resolvedByEmail: doc.resolvedByEmail ?? null,
 			comment: doc.comment ?? null,
+			escalationSent: doc.escalationSent ?? false,
 			createdAt: this.toDateString(doc.createdAt),
 			updatedAt: this.toDateString(doc.updatedAt),
 		};

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -391,6 +391,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalationRules: doc.escalationRules ?? undefined,
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};
@@ -450,6 +451,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalationRules: doc.escalationRules ?? undefined,
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};

--- a/server/src/service/business/incidentService.ts
+++ b/server/src/service/business/incidentService.ts
@@ -90,6 +90,7 @@ export class IncidentService implements IIncidentService {
 					status: true,
 					statusCode,
 					message,
+					escalationSent: false,
 				};
 				return await this.incidentsRepository.create(incident);
 			}

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -38,7 +38,7 @@ export interface MonitorActionDecision {
 	shouldResolveIncident: boolean;
 	shouldSendNotification: boolean;
 	incidentReason: "status_down" | "threshold_breach" | null;
-	notificationReason: "status_change" | "threshold_breach" | null;
+	notificationReason: "status_change" | "threshold_breach" | "escalation" | null;
 	thresholdBreaches?: {
 		cpu?: boolean;
 		memory?: boolean;
@@ -177,6 +177,17 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 						stack: error instanceof Error ? error.stack : undefined,
 					});
 				});
+				// Step 8. Handle escalations (best effort, don't wait)
+				if (statusChangeResult.monitor.status === "down" && statusChangeResult.monitor.escalationRules) {
+					this.handleEscalationNotifications(statusChangeResult.monitor, status).catch((error: unknown) => {
+						this.logger.error({
+							message: `Error handling escalation notifications for monitor ${statusChangeResult.monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+							service: SERVICE_NAME,
+							method: "getMonitorJob",
+							stack: error instanceof Error ? error.stack : undefined,
+						});
+					});
+				}
 			} catch (error: unknown) {
 				this.logger.warn({
 					message: error instanceof Error ? error.message : "Unknown error",
@@ -455,4 +466,77 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 
 		return decision;
 	}
+	private handleEscalationNotifications = async (
+		monitor: Monitor,
+		monitorStatusResponse: Parameters<INotificationsService["handleNotifications"]>[1]
+	): Promise<void> => {
+		this.logger.info({
+			message: `Escalation check for monitor ${monitor.id}, rules: ${JSON.stringify(monitor.escalationRules)}, status: ${monitor.status}`,
+			service: SERVICE_NAME,
+			method: "handleEscalationNotifications",
+		});
+
+		if (monitor.status !== "down" || !monitor.escalationRules) {
+			return;
+		}
+
+		const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId);
+		this.logger.info({
+			message: `Active incident lookup for monitor ${monitor.id}: id=${activeIncident?.id ?? "none"}, escalationSent=${activeIncident?.escalationSent ?? "n/a"}`,
+			service: SERVICE_NAME,
+			method: "handleEscalationNotifications",
+		});
+		if (!activeIncident) {
+			return;
+		}
+
+		if (activeIncident.escalationSent) {
+			return;
+		}
+
+		const elapsedMs = Date.now() - new Date(activeIncident.startTime).getTime();
+		if (elapsedMs < monitor.escalationRules.afterMinutes * 60_000) {
+			return;
+		}
+
+		if (monitor.escalationRules.notificationIds.length === 0) {
+			return;
+		}
+
+		const escalationMonitor: Monitor = {
+			...monitor,
+			notifications: monitor.escalationRules.notificationIds,
+		};
+
+		const sendSuccess = await this.notificationsService.handleNotifications(escalationMonitor, monitorStatusResponse, {
+			shouldCreateIncident: false,
+			shouldResolveIncident: false,
+			shouldSendNotification: true,
+			incidentReason: null,
+			notificationReason: "escalation",
+		});
+		this.logger.info({
+			message: `Escalation notification send result for monitor ${monitor.id}: ${sendSuccess}`,
+			service: SERVICE_NAME,
+			method: "handleEscalationNotifications",
+		});
+
+		if (!sendSuccess) {
+			this.logger.warn({
+				message: `Escalation notification send failed for monitor ${monitor.id}`,
+				service: SERVICE_NAME,
+				method: "handleEscalationNotifications",
+			});
+			return;
+		}
+
+		await this.incidentsRepository.updateById(activeIncident.id, activeIncident.teamId, {
+			escalationSent: true,
+		});
+		this.logger.info({
+			message: "escalationSent persisted",
+			service: SERVICE_NAME,
+			method: "handleEscalationNotifications",
+		});
+	};
 }

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -31,7 +31,7 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	): NotificationMessage {
 		const type = this.determineNotificationType(decision, monitor);
 		const severity = this.determineSeverity(type);
-		const content = this.buildContent(type, monitor, monitorStatusResponse);
+		const content = this.buildContent(type, monitor, monitorStatusResponse, decision);
 
 		return {
 			type,
@@ -53,6 +53,10 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	}
 
 	private determineNotificationType(decision: MonitorActionDecision, monitor: Monitor): NotificationType {
+		if (decision.notificationReason === "escalation") {
+			return "escalation";
+		}
+
 		// Down status has highest priority (critical)
 		if (monitor.status === "down") {
 			return "monitor_down";
@@ -80,6 +84,7 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	private determineSeverity(type: NotificationType): NotificationSeverity {
 		switch (type) {
 			case "monitor_down":
+			case "escalation":
 				return "critical";
 			case "threshold_breach":
 				return "warning";
@@ -93,10 +98,16 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		}
 	}
 
-	private buildContent(type: NotificationType, monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): NotificationContent {
+	private buildContent(
+		type: NotificationType,
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		decision: MonitorActionDecision
+	): NotificationContent {
 		switch (type) {
 			case "monitor_down":
-				return this.buildMonitorDownContent(monitor, monitorStatusResponse);
+			case "escalation":
+				return this.buildMonitorDownContent(monitor, monitorStatusResponse, decision);
 			case "monitor_up":
 				return this.buildMonitorUpContent(monitor);
 			case "threshold_breach":
@@ -108,9 +119,18 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		}
 	}
 
-	private buildMonitorDownContent(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): NotificationContent {
-		const title = `Monitor Down: ${monitor.name}`;
-		const summary = `Monitor "${monitor.name}" is currently down and unreachable.`;
+	private buildMonitorDownContent(
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		decision: MonitorActionDecision
+	): NotificationContent {
+		const isEscalation = decision.notificationReason === "escalation";
+		const title = isEscalation
+			? `Escalation Alert: ${monitor.name} is still down`
+			: `Monitor Down: ${monitor.name}`;
+		const summary = isEscalation
+			? `Monitor ${monitor.name} has been down and requires escalation attention.`
+			: `Monitor "${monitor.name}" is currently down and unreachable.`;
 		const details = [`URL: ${monitor.url}`, `Status: Down`, `Type: ${monitor.type}`];
 
 		// Add response code if available

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -125,9 +125,7 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		decision: MonitorActionDecision
 	): NotificationContent {
 		const isEscalation = decision.notificationReason === "escalation";
-		const title = isEscalation
-			? `Escalation Alert: ${monitor.name} is still down`
-			: `Monitor Down: ${monitor.name}`;
+		const title = isEscalation ? `Escalation Alert: ${monitor.name} is still down` : `Monitor Down: ${monitor.name}`;
 		const summary = isEscalation
 			? `Monitor ${monitor.name} has been down and requires escalation attention.`
 			: `Monitor "${monitor.name}" is currently down and unreachable.`;

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -87,6 +87,8 @@ export class EmailProvider implements INotificationProvider {
 				return `Monitor ${message.monitor.name} threshold exceeded`;
 			case "threshold_resolved":
 				return `Monitor ${message.monitor.name} thresholds resolved`;
+			case "escalation":
+				return `Escalation: Monitor ${message.monitor.name} is still down`;
 			default:
 				return `Alert: ${message.monitor.name}`;
 		}

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,7 +14,6 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
-
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
 }
@@ -140,7 +139,6 @@ export class NotificationsService implements INotificationsService {
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
 	};
-
 	sendTestNotification = async (notification: Partial<Notification>) => {
 		switch (notification.type) {
 			case "email":

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -18,6 +18,7 @@ export interface Incident {
 	comment?: string | null;
 	createdAt: string;
 	updatedAt: string;
+	escalationSent: boolean;
 }
 
 export interface IncidentSummaryTopMonitor {

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -56,6 +56,7 @@ export interface Monitor {
 	recentChecks: CheckSnapshot[];
 	createdAt: string;
 	updatedAt: string;
+	escalationRules?: EscalationRule;
 }
 
 export interface MonitorsSummary {
@@ -157,6 +158,11 @@ export interface Game {
 	extra?: {
 		old_id?: string;
 	};
+}
+
+export interface EscalationRule {
+	afterMinutes: number;
+	notificationIds: string[];
 }
 
 export type GamesMap = Record<string, Game>;

--- a/server/src/types/notificationMessage.ts
+++ b/server/src/types/notificationMessage.ts
@@ -3,7 +3,7 @@
  * Part of notification system unification effort
  */
 
-export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test";
+export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "escalation" | "test";
 
 export type NotificationSeverity = "critical" | "warning" | "info" | "success";
 

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -78,6 +78,12 @@ export const createMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalationRules: z
+		.object({
+			afterMinutes: z.number().min(0),
+			notificationIds: z.array(z.string()).min(1, "At least one notification channel is required"),
+		})
+		.optional(),
 });
 
 export const editMonitorBodyValidation = z.object({
@@ -107,6 +113,12 @@ export const editMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalationRules: z
+		.object({
+			afterMinutes: z.number().min(0),
+			notificationIds: z.array(z.string()).min(1, "At least one notification channel is required"),
+		})
+		.optional(),
 });
 
 export const pauseMonitorParamValidation = z.object({
@@ -160,6 +172,12 @@ const importedMonitorSchema = z.object({
 	geoCheckEnabled: z.boolean().default(false),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).default([]),
 	geoCheckInterval: z.number().min(300000).default(300000),
+	escalationRules: z
+		.object({
+			afterMinutes: z.number().min(0),
+			notificationIds: z.array(z.string()).min(1, "At least one notification channel is required"),
+		})
+		.optional(),
 	createdAt: z.string().optional(),
 	updatedAt: z.string().optional(),
 });


### PR DESCRIPTION
## Describe your changes

Implemented escalated notifications for the Checkmate monitoring platform. When a monitor remains down for a user-defined duration, an escalation email is sent to a specified notification channel. Changes include:

Added escalationRules field to the monitor model (frontend and backend) with afterMinutes and notificationIds fields
Added escalationSent boolean to the incident model to prevent duplicate escalation emails per incident
Added escalation check logic in SuperSimpleQueueHelper that runs on every heartbeat and fires escalation notifications once the elapsed downtime threshold is met
Added escalation notification type to NotificationMessage and email subject builder
Added escalation rules UI in the Create/Edit Monitor form with a minutes input and notification channel multi-select

## Write your issue number after "Fixes "

Fixes #1 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.