### PR TITLE
Add escalated notifications support

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalationPolicy: data?.escalationPolicy || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useEffect } from "react";
 import { logger } from "@/Utils/logger";
 import { useParams, useLocation, useNavigate } from "react-router";
-import { useForm, Controller } from "react-hook-form";
+import { useForm, Controller, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTheme } from "@mui/material";
 import Stack from "@mui/material/Stack";
@@ -14,7 +14,7 @@ import Typography from "@mui/material/Typography";
 import Link from "@mui/material/Link";
 import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
-import { Trash2 } from "lucide-react";
+import { Trash2, Plus } from "lucide-react";
 import { HeaderDeleteControls } from "@/Components/monitors";
 import { GeoContinents } from "@/Types/GeoCheck";
 
@@ -203,6 +203,15 @@ const CreateMonitorPage = () => {
 		defaultValues: defaults,
 	});
 	const { control, watch, handleSubmit, clearErrors } = form;
+
+	const {
+		fields: escalationFields,
+		append: appendEscalation,
+		remove: removeEscalation,
+	} = useFieldArray({
+		control,
+		name: "escalationPolicy" as never,
+	});
 
 	useEffect(() => {
 		form.reset(defaults);
@@ -762,6 +771,92 @@ const CreateMonitorPage = () => {
 							);
 						}}
 					/>
+				}
+			/>
+
+			<ConfigBox
+				title="Escalated Notifications"
+				subtitle="Send additional notifications if an incident remains unresolved after a delay."
+				rightContent={
+					<Stack spacing={theme.spacing(LAYOUT.MD)}>
+						{escalationFields.map((field, index) => {
+							const notificationOptions = (notifications ?? []).map((n) => ({
+								...n,
+								name: n.notificationName,
+							}));
+							return (
+								<Stack
+									key={field.id}
+									direction="row"
+									alignItems="center"
+									spacing={theme.spacing(SPACING.LG)}
+								>
+									<Controller
+										name={`escalationPolicy.${index}.delayMinutes` as never}
+										control={control}
+										render={({ field: delayField }) => (
+											<TextField
+												type="number"
+												label="Delay (min)"
+												value={delayField.value ?? 0}
+												onChange={(e) =>
+													delayField.onChange(Number(e.target.value))
+												}
+												sx={{ width: 160 }}
+											/>
+										)}
+									/>
+									<Controller
+										name={`escalationPolicy.${index}.notificationId` as never}
+										control={control}
+										render={({ field: notifField }) => {
+											const selected =
+												notificationOptions.find(
+													(n) => n.id === notifField.value
+												) ?? null;
+											return (
+												<Autocomplete
+													options={notificationOptions}
+													value={selected}
+													getOptionLabel={(option) => option.name}
+													onChange={(
+														_: unknown,
+														newValue: (typeof notificationOptions)[number] | null
+													) => {
+														notifField.onChange(newValue?.id ?? "");
+													}}
+													isOptionEqualToValue={(option, value) =>
+														option.id === value.id
+													}
+													sx={{ flex: 1 }}
+												/>
+											);
+										}}
+									/>
+									<IconButton
+										size="small"
+										onClick={() => removeEscalation(index)}
+										aria-label="Remove escalation tier"
+									>
+										<Trash2 size={16} />
+									</IconButton>
+								</Stack>
+							);
+						})}
+						<Button
+							variant="text"
+							onClick={() =>
+								(appendEscalation as (value: { delayMinutes: number; notificationId: string }) => void)({
+									delayMinutes: 0,
+									notificationId: "",
+								})
+							}
+							sx={{ alignSelf: "flex-start" }}
+						>
+							<Plus size={16} />
+							&nbsp;Add escalation tier
+						</Button>
+					</Stack>
 				}
 			/>
 

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface EscalationTier {
+	delayMinutes: number;
+	notificationId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -76,6 +81,7 @@ export interface Monitor {
 	geoCheckEnabled?: boolean;
 	geoCheckLocations?: GeoContinent[];
 	geoCheckInterval?: number;
+	escalationPolicy?: EscalationTier[];
 	recentChecks: CheckSnapshot[];
 	createdAt: string;
 	updatedAt: string;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -4,6 +4,21 @@ import { GeoContinents } from "@/Types/GeoCheck";
 // URL schema with custom error message
 const urlSchema = z.url({ message: "Please enter a valid URL" });
 
+const escalationTierSchema = z.object({
+	delayMinutes: z.number().min(0, "Delay must be 0 or more"),
+	notificationId: z.string().min(1, "Notification channel is required"),
+});
+
+const escalationPolicySchema = z
+	.array(escalationTierSchema)
+	.refine(
+		(tiers) => {
+			const delays = tiers.map((t) => t.delayMinutes);
+			return new Set(delays).size === delays.length;
+		},
+		{ message: "Each escalation tier must have a unique delay" }
+	);
+
 // Common base schema for all monitor types
 const baseSchema = z.object({
 	name: z
@@ -27,6 +42,7 @@ const baseSchema = z.object({
 		.number()
 		.min(300000, "Interval must be at least 5 minutes")
 		.optional(),
+	escalationPolicy: escalationPolicySchema.optional(),
 });
 
 // HTTP monitor schema

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -72,6 +72,10 @@ const IncidentSchema = new Schema<IncidentDocument>(
 			type: String,
 			default: null,
 		},
+		lastEscalatedTier: {
+			type: Number,
+			default: -1,
+		},
 	},
 	{ timestamps: true }
 );

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -284,6 +284,16 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalationPolicy: {
+			type: [
+				{
+					delayMinutes: { type: Number, required: true },
+					notificationId: { type: String, required: true },
+					_id: false,
+				},
+			],
+			default: [],
+		},
 		secret: {
 			type: String,
 		},

--- a/server/src/repositories/incidents/MongoIncidentRepository.ts
+++ b/server/src/repositories/incidents/MongoIncidentRepository.ts
@@ -60,6 +60,7 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			resolvedBy: doc.resolvedBy ? this.toStringId(doc.resolvedBy) : null,
 			resolvedByEmail: doc.resolvedByEmail ?? null,
 			comment: doc.comment ?? null,
+			lastEscalatedTier: doc.lastEscalatedTier ?? -1,
 			createdAt: this.toDateString(doc.createdAt),
 			updatedAt: this.toDateString(doc.updatedAt),
 		};

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -391,6 +391,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalationPolicy: doc.escalationPolicy ?? [],
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};
@@ -450,6 +451,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalationPolicy: doc.escalationPolicy ?? [],
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -1,5 +1,5 @@
 const SERVICE_NAME = "JobQueueHelper";
-import type { Monitor } from "@/types/monitor.js";
+import type { Monitor, EscalationTier } from "@/types/monitor.js";
 import { supportsGeoCheck } from "@/types/monitor.js";
 import { AppError } from "@/utils/AppError.js";
 import {
@@ -11,7 +11,7 @@ import {
 	IncidentService,
 	type IGeoChecksService,
 } from "@/service/index.js";
-import { CHECK_TTL_SENTINEL, type MaintenanceWindow, type StatusChangeResult } from "@/types/index.js";
+import { CHECK_TTL_SENTINEL, type MaintenanceWindow, type StatusChangeResult, type MonitorStatusResponse } from "@/types/index.js";
 import {
 	IMaintenanceWindowsRepository,
 	IMonitorsRepository,
@@ -38,7 +38,7 @@ export interface MonitorActionDecision {
 	shouldResolveIncident: boolean;
 	shouldSendNotification: boolean;
 	incidentReason: "status_down" | "threshold_breach" | null;
-	notificationReason: "status_change" | "threshold_breach" | null;
+	notificationReason: "status_change" | "threshold_breach" | "escalation" | null;
 	thresholdBreaches?: {
 		cpu?: boolean;
 		memory?: boolean;
@@ -177,6 +177,32 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 						stack: error instanceof Error ? error.stack : undefined,
 					});
 				});
+
+				// Step 8. Handle escalation notifications (best effort, don't wait)
+				const updatedMonitor = statusChangeResult.monitor;
+				const escalationPolicy = updatedMonitor.escalationPolicy ?? [];
+				if (escalationPolicy.length > 0 && !decision.shouldResolveIncident) {
+					this.handleEscalation(updatedMonitor, escalationPolicy, status).catch((error: unknown) => {
+						this.logger.warn({
+							message: `Error handling escalation for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+							service: SERVICE_NAME,
+							method: "getMonitorJob",
+							stack: error instanceof Error ? error.stack : undefined,
+						});
+					});
+				}
+
+				// Step 8b. On resolution, send resolution to previously-escalated channels
+				if (escalationPolicy.length > 0 && decision.shouldResolveIncident) {
+					this.handleEscalationResolution(updatedMonitor, escalationPolicy, status, decision).catch((error: unknown) => {
+						this.logger.warn({
+							message: `Error sending escalation resolution for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+							service: SERVICE_NAME,
+							method: "getMonitorJob",
+							stack: error instanceof Error ? error.stack : undefined,
+						});
+					});
+				}
 			} catch (error: unknown) {
 				this.logger.warn({
 					message: error instanceof Error ? error.message : "Unknown error",
@@ -416,6 +442,67 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 				});
 			}
 		};
+	};
+
+	private handleEscalation = async (
+		monitor: Monitor,
+		escalationPolicy: EscalationTier[],
+		monitorStatusResponse: MonitorStatusResponse
+	): Promise<void> => {
+		const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId);
+		if (!activeIncident || !activeIncident.status) return;
+
+		const incidentStart = new Date(activeIncident.startTime).getTime();
+		const elapsedMinutes = (Date.now() - incidentStart) / 60000;
+		const lastTier = activeIncident.lastEscalatedTier ?? -1;
+
+		// Find tiers that are due but haven't been sent yet
+		const sortedTiers = [...escalationPolicy].sort((a, b) => a.delayMinutes - b.delayMinutes);
+		const dueTiers = sortedTiers.filter((t) => t.delayMinutes > lastTier && t.delayMinutes <= elapsedMinutes);
+
+		if (dueTiers.length === 0) return;
+
+		const notificationIds = dueTiers.map((t) => t.notificationId);
+		const escalationDecision: MonitorActionDecision = {
+			shouldCreateIncident: false,
+			shouldResolveIncident: false,
+			shouldSendNotification: true,
+			incidentReason: "status_down",
+			notificationReason: "escalation",
+		};
+
+		await this.notificationsService.sendToNotificationIds(notificationIds, monitor, monitorStatusResponse, escalationDecision);
+
+		const highestTier = Math.max(...dueTiers.map((t) => t.delayMinutes));
+		await this.incidentsRepository.updateById(activeIncident.id, activeIncident.teamId, {
+			lastEscalatedTier: highestTier,
+		});
+
+		this.logger.info({
+			message: `Sent escalation notifications for monitor ${monitor.id}: tiers [${dueTiers.map((t) => `${t.delayMinutes}min`).join(", ")}]`,
+			service: SERVICE_NAME,
+			method: "handleEscalation",
+		});
+	};
+
+	private handleEscalationResolution = async (
+		monitor: Monitor,
+		escalationPolicy: EscalationTier[],
+		monitorStatusResponse: MonitorStatusResponse,
+		decision: MonitorActionDecision
+	): Promise<void> => {
+		const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId);
+		if (!activeIncident) return;
+
+		const lastTier = activeIncident.lastEscalatedTier ?? -1;
+		if (lastTier < 0) return; // No escalation tiers were ever sent
+
+		// Send resolution to all previously-escalated channels
+		const notifiedTiers = escalationPolicy.filter((t) => t.delayMinutes <= lastTier);
+		if (notifiedTiers.length === 0) return;
+
+		const notificationIds = [...new Set(notifiedTiers.map((t) => t.notificationId))];
+		await this.notificationsService.sendToNotificationIds(notificationIds, monitor, monitorStatusResponse, decision);
 	};
 
 	private evaluateMonitorAction(statusChangeResult: StatusChangeResult): MonitorActionDecision {

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -53,6 +53,11 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	}
 
 	private determineNotificationType(decision: MonitorActionDecision, monitor: Monitor): NotificationType {
+		// Escalation has its own distinct type
+		if (decision.notificationReason === "escalation") {
+			return "escalation";
+		}
+
 		// Down status has highest priority (critical)
 		if (monitor.status === "down") {
 			return "monitor_down";
@@ -80,6 +85,7 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	private determineSeverity(type: NotificationType): NotificationSeverity {
 		switch (type) {
 			case "monitor_down":
+			case "escalation":
 				return "critical";
 			case "threshold_breach":
 				return "warning";
@@ -97,6 +103,8 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		switch (type) {
 			case "monitor_down":
 				return this.buildMonitorDownContent(monitor, monitorStatusResponse);
+			case "escalation":
+				return this.buildEscalationContent(monitor, monitorStatusResponse);
 			case "monitor_up":
 				return this.buildMonitorUpContent(monitor);
 			case "threshold_breach":
@@ -119,6 +127,27 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		}
 
 		// Add error message if available
+		if (monitorStatusResponse.message) {
+			details.push(`Error: ${monitorStatusResponse.message}`);
+		}
+
+		return {
+			title,
+			summary,
+			details,
+			timestamp: new Date(),
+		};
+	}
+
+	private buildEscalationContent(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): NotificationContent {
+		const title = `Escalation: ${monitor.name} still down`;
+		const summary = `Monitor "${monitor.name}" remains down and unresolved.`;
+		const details = [`URL: ${monitor.url}`, `Status: Down`, `Type: ${monitor.type}`];
+
+		if (monitorStatusResponse.code) {
+			details.push(`Response Code: ${monitorStatusResponse.code}`);
+		}
+
 		if (monitorStatusResponse.message) {
 			details.push(`Error: ${monitorStatusResponse.message}`);
 		}

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -81,6 +81,8 @@ export class EmailProvider implements INotificationProvider {
 		switch (message.type) {
 			case "monitor_down":
 				return `Monitor ${message.monitor.name} is down`;
+			case "escalation":
+				return `Escalation: Monitor ${message.monitor.name} still down`;
 			case "monitor_up":
 				return `Monitor ${message.monitor.name} is back up`;
 			case "threshold_breach":

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,6 +14,12 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	sendToNotificationIds: (
+		notificationIds: string[],
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		decision: MonitorActionDecision
+	) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -139,6 +145,26 @@ export class NotificationsService implements INotificationsService {
 
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	sendToNotificationIds = async (
+		notificationIds: string[],
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		decision: MonitorActionDecision
+	): Promise<boolean> => {
+		if (notificationIds.length === 0) return true;
+		const notifications = await this.notificationsRepository.findNotificationsByIds(notificationIds);
+		if (notifications.length === 0) return true;
+
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+		const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, decision, clientHost);
+
+		const tasks = notifications.map((notification) => this.send(notification, monitor, monitorStatusResponse, decision, notificationMessage));
+		const outcomes = await Promise.all(tasks);
+		const succeeded = outcomes.filter(Boolean).length;
+		return succeeded === notifications.length;
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -16,6 +16,7 @@ export interface Incident {
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;
 	comment?: string | null;
+	lastEscalatedTier?: number;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -53,9 +53,15 @@ export interface Monitor {
 	geoCheckEnabled?: boolean;
 	geoCheckLocations?: GeoContinent[];
 	geoCheckInterval?: number;
+	escalationPolicy?: EscalationTier[];
 	recentChecks: CheckSnapshot[];
 	createdAt: string;
 	updatedAt: string;
+}
+
+export interface EscalationTier {
+	delayMinutes: number;
+	notificationId: string;
 }
 
 export interface MonitorsSummary {

--- a/server/src/types/notificationMessage.ts
+++ b/server/src/types/notificationMessage.ts
@@ -3,7 +3,7 @@
  * Part of notification system unification effort
  */
 
-export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test";
+export type NotificationType = "monitor_down" | "monitor_up" | "escalation" | "threshold_breach" | "threshold_resolved" | "test";
 
 export type NotificationSeverity = "critical" | "warning" | "info" | "success";
 

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -78,6 +78,14 @@ export const createMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalationPolicy: z
+		.array(
+			z.object({
+				delayMinutes: z.number().min(0),
+				notificationId: z.string().min(1),
+			})
+		)
+		.optional(),
 });
 
 export const editMonitorBodyValidation = z.object({
@@ -107,6 +115,14 @@ export const editMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalationPolicy: z
+		.array(
+			z.object({
+				delayMinutes: z.number().min(0),
+				notificationId: z.string().min(1),
+			})
+		)
+		.optional(),
 });
 
 export const pauseMonitorParamValidation = z.object({


### PR DESCRIPTION
## Summary
Implemented per-monitor escalated notifications for Checkmate.

## Changes
- Added an Escalated Notifications configuration section to the monitor create/edit UI
- Added backend persistence for escalationPolicy so it saves and reloads with monitor data
- Added delayed escalation email handling so a separate escalation email is sent when an incident remains unresolved past the configured delay
- Added distinct escalation email wording/subject separate from normal down and recovery emails

## Testing
- Verified Escalated Notifications UI appears in the monitor form
- Verified escalation tiers persist after save and reload
- Verified email notifications are sent based on configured escalation delay
- Verified normal down, escalation, and recovery email behaviors