### PR TITLE
add escalated notifications for monitors

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalationRules: data?.escalationRules || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/Types/Monitor";
 import type { Notification } from "@/Types/Notification";
 import type { MonitorFormData } from "@/Validation/monitor";
+import type { EscalationRule } from "@/Types/Monitor";
 
 interface GeneralSettingsConfig {
 	urlLabel: string;
@@ -758,6 +759,125 @@ const CreateMonitorPage = () => {
 											))}
 										</Stack>
 									)}
+								</Stack>
+							);
+						}}
+					/>
+				}
+			/>
+
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalations.title")}
+				subtitle={t("pages.createMonitor.form.escalations.description")}
+				rightContent={
+					<Controller
+						name="escalationRules"
+						control={control}
+						render={({ field }) => {
+							const rules: EscalationRule[] = field.value ?? [];
+
+							const notificationOptions = (notifications ?? []).map((n) => ({
+								...n,
+								name: n.notificationName,
+							}));
+
+							const updateRule = (index: number, updated: EscalationRule) => {
+								const next = [...rules];
+								next[index] = updated;
+								field.onChange(next);
+							};
+
+							const addRule = () => {
+								field.onChange([
+									...rules,
+									{ afterMinutes: 5, notificationIds: [] } as EscalationRule,
+								]);
+							};
+
+							const removeRule = (index: number) => {
+								const next = rules.filter((_, i) => i !== index);
+								field.onChange(next);
+							};
+
+							return (
+								<Stack spacing={theme.spacing(LAYOUT.MD)}>
+									<Button
+										variant="outlined"
+										onClick={addRule}
+										disabled={isSubmitting}
+									>
+										{t("pages.createMonitor.form.escalations.add")}
+									</Button>
+
+									{rules.length === 0 && (
+										<Typography color="text.secondary">
+											{t("pages.createMonitor.form.escalations.empty")}
+										</Typography>
+									)}
+
+									{rules.map((rule, index) => {
+										const selectedNotifications = notificationOptions.filter((n) =>
+											(rule.notificationIds ?? []).includes(n.id)
+										);
+										return (
+											<Stack
+												key={`escalation-${index}`}
+												spacing={theme.spacing(SPACING.MD)}
+												sx={{
+													border: `1px solid ${theme.palette.divider}`,
+													borderRadius: theme.spacing(1),
+													p: theme.spacing(SPACING.MD),
+												}}
+											>
+												<Stack
+													direction={{ xs: "column", md: "row" }}
+													spacing={theme.spacing(SPACING.MD)}
+													alignItems={{ md: "center" }}
+												>
+													<TextField
+														type="number"
+														fieldLabel={t("pages.createMonitor.form.escalations.afterMinutes")}
+														value={rule.afterMinutes}
+														onChange={(e) =>
+															updateRule(index, {
+																...rule,
+																afterMinutes: Number(e.target.value) || 0,
+															})
+														}
+														inputProps={{ min: 1 }}
+														sx={{ maxWidth: 240 }}
+													/>
+
+													<Autocomplete
+														multiple
+														options={notificationOptions}
+														value={selectedNotifications}
+														getOptionLabel={(option) => option.name}
+														onChange={(_: unknown, newValue: typeof notificationOptions) =>
+															updateRule(index, {
+																...rule,
+																notificationIds: newValue.map((n) => n.id),
+															})
+														}
+														isOptionEqualToValue={(option, value) => option.id === value.id}
+														fieldLabel={t(
+															"pages.createMonitor.form.escalations.channels"
+														)}
+														sx={{ flex: 1, minWidth: 260 }}
+													/>
+
+													<IconButton
+														size="small"
+														onClick={() => removeRule(index)}
+														aria-label="Remove escalation rule"
+														disabled={isSubmitting}
+													>
+														<Trash2 size={16} />
+													</IconButton>
+												</Stack>
+											</Stack>
+										);
+									})}
 								</Stack>
 							);
 						}}

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface EscalationRule {
+	afterMinutes: number;
+	notificationIds: string[];
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +65,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationRules?: EscalationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -13,6 +13,15 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalationRules: z
+		.array(
+			z.object({
+				afterMinutes: z.number().min(1, "Escalation time must be at least 1 minute"),
+				notificationIds: z.array(z.string().min(1, "Select at least one notification channel")),
+			})
+		)
+		.optional()
+		.default([]),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -543,6 +543,14 @@
 					"description": "Select the notification channels you want to use",
 					"title": "Notifications"
 				},
+				"escalations": {
+					"title": "Escalation rules",
+					"description": "If the monitor stays down for the specified time, notify additional channels.",
+					"add": "Add escalation rule",
+					"afterMinutes": "Escalate after (minutes)",
+					"channels": "Escalation notification channels",
+					"empty": "No escalation rules configured yet."
+				},
 				"type": {
 					"description": "Select the type of check to perform",
 					"optionDockerDescription": "Use Docker to monitor if a container is running.",

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -284,6 +284,12 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalationRules: [
+			{
+				afterMinutes: { type: Number, min: 1, required: true },
+				notificationIds: [{ type: Schema.Types.ObjectId, ref: "Notification", required: true }],
+			},
+		],
 		secret: {
 			type: String,
 		},

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -351,6 +351,11 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification) => toStringId(notification));
+		const escalationRules =
+			doc.escalationRules?.map((rule) => ({
+				afterMinutes: rule.afterMinutes,
+				notificationIds: (rule.notificationIds ?? []).map((n: unknown) => toStringId(n)),
+			})) ?? [];
 
 		return {
 			id: toStringId(doc._id),
@@ -374,6 +379,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalationRules,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -410,6 +416,11 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification: unknown) => toStringId(notification));
+		const escalationRules =
+			doc.escalationRules?.map((rule) => ({
+				afterMinutes: rule.afterMinutes,
+				notificationIds: (rule.notificationIds ?? []).map((n: unknown) => toStringId(n)),
+			})) ?? [];
 
 		return {
 			id: toStringId(doc._id),
@@ -433,6 +444,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalationRules,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -107,8 +107,16 @@ export class NotificationsService implements INotificationsService {
 		}
 	};
 
-	private sendNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
-		const notificationIds = monitor.notifications ?? [];
+	private sendNotifications = async (
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		decision: MonitorActionDecision,
+		notificationIdsOverride?: string[]
+	) => {
+		const notificationIds = notificationIdsOverride ?? monitor.notifications ?? [];
+		if (!notificationIds.length) {
+			return true;
+		}
 		const notifications = await this.notificationsRepository.findNotificationsByIds(notificationIds);
 
 		// Build notification message once for all notifications
@@ -132,13 +140,48 @@ export class NotificationsService implements INotificationsService {
 		return succeeded === notifications.length;
 	};
 
+	private scheduleEscalations = (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
+		if (!monitor.escalationRules?.length) {
+			return;
+		}
+
+		if (monitor.status !== "down" && monitor.status !== "breached") {
+			return;
+		}
+
+		for (const rule of monitor.escalationRules) {
+			const delayMs = Math.max(1, rule.afterMinutes) * 60_000;
+			setTimeout(async () => {
+				try {
+					const latest = await this.monitorsRepository.findById(monitor.id, monitor.teamId);
+					if (latest.status !== "down" && latest.status !== "breached") {
+						return;
+					}
+					await this.sendNotifications(latest, monitorStatusResponse, decision, rule.notificationIds);
+				} catch (error: unknown) {
+					this.logger.warn({
+						message: `Failed to send escalation notification for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+						service: SERVICE_NAME,
+						method: "scheduleEscalations",
+						stack: error instanceof Error ? error.stack : undefined,
+					});
+				}
+			}, delayMs);
+		}
+	};
+
 	handleNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
 		if (!decision.shouldSendNotification) {
 			return false;
 		}
 
 		// Send notifications based on decision
-		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+		const result = await this.sendNotifications(monitor, monitorStatusResponse, decision);
+
+		// Schedule escalation notifications if configured
+		this.scheduleEscalations(monitor, monitorStatusResponse, decision);
+
+		return result;
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface EscalationRule {
+	afterMinutes: number;
+	notificationIds: string[];
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +42,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationRules?: EscalationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -67,6 +67,14 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalationRules: z
+		.array(
+			z.object({
+				afterMinutes: z.number().min(1),
+				notificationIds: z.array(z.string()),
+			})
+		)
+		.optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -103,6 +111,14 @@ export const editMonitorBodyValidation = z.object({
 	gameId: z.union([z.string(), z.literal("")]).optional(),
 	grpcServiceName: z.union([z.string(), z.literal("")]).optional(),
 	selectedDisks: z.array(z.string()).optional(),
+	escalationRules: z
+		.array(
+			z.object({
+				afterMinutes: z.number().min(1),
+				notificationIds: z.array(z.string()),
+			})
+		)
+		.optional(),
 	group: z.union([z.string().max(50).trim(), z.null(), z.literal("")]).optional(),
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
@@ -144,6 +160,14 @@ const importedMonitorSchema = z.object({
 	interval: z.number().default(60000),
 	uptimePercentage: z.number().optional(),
 	notifications: z.array(z.string()).default([]),
+	escalationRules: z
+		.array(
+			z.object({
+				afterMinutes: z.number().min(1),
+				notificationIds: z.array(z.string()),
+			})
+		)
+		.default([]),
 	secret: z.string().optional(),
 	cpuAlertThreshold: z.number().default(100),
 	cpuAlertCounter: z.number().default(5),


### PR DESCRIPTION
Tej Allada

So I updated the monitors to now carry an escalation rules value in both the server and client side. I added the box to interact with on the front end so users can now add/remove update the time for escalation and the notification mail. I also updated the notification and email sender to send the email to the selected email for the new escalation rule

