### PR TITLE
feat: Escalated Notficiations

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalations: data?.escalations || { delayMinutes: 0, notificationIds: [] },
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -765,6 +765,93 @@ const CreateMonitorPage = () => {
 				}
 			/>
 
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalations.title")}
+				subtitle={t("pages.createMonitor.form.escalations.description")}
+				rightContent={
+					<Controller
+						name="escalations"
+						control={control}
+						render={({ field }) => {
+							const escalationOptions = (notifications ?? []).map((n) => ({
+								...n,
+								name: n.notificationName,
+							}));
+							const selectedEscalations = escalationOptions.filter((n) =>
+									(field.value?.notificationIds ?? []).includes(n.id)
+								);
+								const delayMinutes = field.value?.delayMinutes ?? 0;
+
+								return (
+									<Stack spacing={theme.spacing(LAYOUT.MD)}>
+										<TextField
+											fieldLabel={t("pages.createMonitor.form.escalations.option.threshold.label")}
+											type="number"
+											value={delayMinutes}
+											onChange={(e) => {
+												const parsed = Number(e.target.value);
+												field.onChange({
+													...(field.value ?? { delayMinutes: 0, notificationIds: [] }),
+													delayMinutes: Number.isNaN(parsed) ? 0 : parsed,
+												});
+											}}
+											inputProps={{ min: 0 }}
+										/>
+										<Autocomplete
+											multiple
+											fieldLabel={t("pages.createMonitor.form.escalations.option.channels.label")}
+											options={escalationOptions}
+											value={selectedEscalations}
+											getOptionLabel={(option) => option.name}
+											onChange={(_: unknown, newValue: typeof escalationOptions) => {
+												field.onChange({
+													...(field.value ?? { delayMinutes: 0, notificationIds: [] }),
+													notificationIds: newValue.map((e) => e.id),
+												});
+											}}
+											isOptionEqualToValue={(option, value) => option.id === value.id}
+										/>
+										{selectedEscalations.length > 0 && (
+											<Stack
+												flex={1}
+												width="100%"
+											>
+												{selectedEscalations.map((escalation, index) => (
+													<Stack
+														direction="row"
+														alignItems="center"
+														key={escalation.id}
+														width="100%"
+													>
+														<Typography flexGrow={1}>
+															{escalation.notificationName}
+														</Typography>
+														<IconButton
+															size="small"
+															onClick={() => {
+                                                field.onChange({
+                                                        ...(field.value ?? { delayMinutes: 0, notificationIds: [] }),
+                                                        notificationIds: (field.value?.notificationIds ?? []).filter(
+                                                                (id: string) => id !== escalation.id
+                                                        ),
+                                                });
+                                            }}
+                                            aria-label="Remove notification"
+                                        >
+                                            <Trash2 size={16} />
+                                        </IconButton>
+                                        {index < selectedEscalations.length - 1 && <Divider />}
+                                    </Stack>
+                                ))}
+                            </Stack>
+                        )}
+                    </Stack>
+                );
+            }}
+        />
+    }
+                />
+
 			{(watchedType === "http" ||
 				watchedType === "grpc" ||
 				watchedType === "websocket") && (

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface MonitorEscalations {
+	delayMinutes: number;
+	notificationIds: string[];
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +65,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalations: MonitorEscalations;
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -13,6 +13,10 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalations: z.object({
+		delayMinutes: z.coerce.number().min(0, "Delay must be at least 0"),
+		notificationIds: z.array(z.string()),
+	}),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -543,6 +543,18 @@
 					"description": "Select the notification channels you want to use",
 					"title": "Notifications"
 				},
+				"escalations": {
+					"description": "If the monitor stays down for the specified time, notify additional channels.",
+					"title": "Escalation Rules",
+					"option": {
+						"threshold":{
+							"label": "Escalate after (minutes)"
+						},
+						"channels": {
+							"label": "Escalation notification channels"
+						}
+					}
+				},
 				"type": {
 					"description": "Select the type of check to perform",
 					"optionDockerDescription": "Use Docker to monitor if a container is running.",

--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -8,6 +8,7 @@ import {
 	GlobalPingService,
 	SuperSimpleQueue,
 	SuperSimpleQueueHelper,
+	EscalationJobQueue,
 	NotificationsService,
 	StatusService,
 	NotificationMessageBuilder,
@@ -33,6 +34,7 @@ import {
 	IEmailService,
 	IBufferService,
 	ISuperSimpleQueue,
+	IEscalationJobQueue,
 	INotificationsService,
 	IStatusService,
 	IMonitorService,
@@ -129,6 +131,7 @@ export type InitializedServices = {
 	incidentService: IIncidentService;
 	logger: ILogger;
 	notificationsService: INotificationsService;
+	escalationJobQueue: IEscalationJobQueue;
 	statusPageService: IStatusPageService;
 	notificationMessageBuilder: INotificationMessageBuilder;
 
@@ -225,7 +228,7 @@ export const initializeServices = async ({
 	// Notification providers
 	const webhookProvider = new WebhookProvider(logger);
 	const slackProvider = new SlackProvider(logger);
-	const emailProvider = new EmailProvider(emailService, logger);
+	const emailProvider = new EmailProvider(emailService, logger, settingsService);
 	const discordProvider = new DiscordProvider(logger);
 	const pagerDutyProvider = new PagerDutyProvider(logger);
 	const matrixProvider = new MatrixProvider(logger);
@@ -245,6 +248,15 @@ export const initializeServices = async ({
 		logger,
 		notificationMessageBuilder
 	);
+
+	const escalationJobQueue = new EscalationJobQueue(
+		logger,
+		notificationsService,
+		monitorsRepository
+	);
+
+	// Set the escalation job queue on the notifications service
+	(notificationsService as any).escalationJobQueue = escalationJobQueue;
 
 	const superSimpleQueueHelper = new SuperSimpleQueueHelper(
 		logger,
@@ -326,6 +338,7 @@ export const initializeServices = async ({
 		incidentService,
 		logger,
 		notificationsService,
+		escalationJobQueue,
 		statusPageService,
 		notificationMessageBuilder,
 

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -18,11 +18,15 @@ type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Dat
 
 type MonitorDocumentBase = Omit<
 	Monitor,
-	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
+	"id" | "userId" | "teamId" | "notifications" | "escalations" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
 > & {
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
+	escalations: {
+		notificationIds: Types.ObjectId[];
+		delayMinutes: number;
+	};
 	selectedDisks: string[];
 	matchMethod?: MonitorMatchMethod;
 };
@@ -173,6 +177,14 @@ const snapshotAuditsSchema = new Schema<CheckAudits>(
 	{ _id: false }
 );
 
+const escalationSchema = new Schema(
+	{
+		notificationIds: [{ type: Schema.Types.ObjectId, ref: "Notification" }],
+		delayMinutes: { type: Number, default: 0 },
+	},
+	{ _id: false }
+);
+
 const checkSnapshotSchema = new Schema<CheckSnapshotDocument>(
 	{
 		id: { type: String, required: true },
@@ -318,6 +330,10 @@ const MonitorSchema = new Schema<MonitorDocument>(
 		tempAlertCounter: {
 			type: Number,
 			default: 5,
+		},
+		escalations: {
+			type: escalationSchema,
+			default: { notificationIds: [], delayMinutes: 0 },
 		},
 		selectedDisks: {
 			type: [String],

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -351,6 +351,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification) => toStringId(notification));
+		const escalations = {
+			delayMinutes: doc.escalations?.delayMinutes ?? 0,
+			notificationIds: (doc.escalations?.notificationIds ?? []).map((notificationId) => toStringId(notificationId)),
+		};
 
 		return {
 			id: toStringId(doc._id),
@@ -374,6 +378,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalations,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -410,6 +415,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification: unknown) => toStringId(notification));
+		const escalations = {
+			delayMinutes: doc.escalations?.delayMinutes ?? 0,
+			notificationIds: (doc.escalations?.notificationIds ?? []).map((notificationId: unknown) => toStringId(notificationId)),
+		};
 
 		return {
 			id: toStringId(doc._id),
@@ -433,6 +442,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalations,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/index.ts
+++ b/server/src/service/index.ts
@@ -12,6 +12,7 @@ export * from "@/service/business/userService.js";
 // Infrastructure services
 export * from "@/service/infrastructure/SuperSimpleQueue/SuperSimpleQueue.js";
 export * from "@/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.js";
+export * from "@/service/infrastructure/escalationJobQueue.js";
 export * from "@/service/infrastructure/notificationMessageBuilder.js";
 export * from "@/service/infrastructure/bufferService.js";
 export * from "@/service/infrastructure/emailService.js";

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -38,7 +38,7 @@ export interface MonitorActionDecision {
 	shouldResolveIncident: boolean;
 	shouldSendNotification: boolean;
 	incidentReason: "status_down" | "threshold_breach" | null;
-	notificationReason: "status_change" | "threshold_breach" | null;
+	notificationReason: "status_change" | "threshold_breach" | "escalation" | null;
 	thresholdBreaches?: {
 		cpu?: boolean;
 		memory?: boolean;

--- a/server/src/service/infrastructure/escalationJobQueue.ts
+++ b/server/src/service/infrastructure/escalationJobQueue.ts
@@ -1,0 +1,382 @@
+import Redis from 'ioredis';
+import { Queue, Worker, type Job } from 'bullmq';
+import { ILogger } from '@/utils/logger.js';
+import type { INotificationsService } from './notificationsService.js';
+import type { IMonitorsRepository } from '@/repositories/index.js';
+
+const SERVICE_NAME = 'EscalationJobQueue';
+
+export interface IEscalationJobQueue {
+	readonly serviceName: string;
+	scheduleEscalation(monitorId: string, teamId: string, delayMinutes: number, notificationIds: string[]): Promise<void>;
+	shutdown(): Promise<void>;
+}
+
+export interface EscalationJobData {
+	monitorId: string;
+	teamId: string;
+	notificationIds: string[];
+}
+
+export class EscalationJobQueue implements IEscalationJobQueue {
+	static SERVICE_NAME = SERVICE_NAME;
+	readonly serviceName = SERVICE_NAME;
+
+	private queue: Queue<EscalationJobData> | null = null;
+	private worker: Worker<EscalationJobData> | null = null;
+	private logger: ILogger;
+	private notificationsService: INotificationsService;
+	private monitorsRepository: IMonitorsRepository;
+	private redisAvailable: boolean = false;
+	private isInitializing: boolean = false;
+
+	constructor(
+		logger: ILogger,
+		notificationsService: INotificationsService,
+		monitorsRepository: IMonitorsRepository,
+		redisUrl?: string
+	) {
+		this.logger = logger;
+		this.notificationsService = notificationsService;
+		this.monitorsRepository = monitorsRepository;
+
+		void this.initialize(redisUrl);
+	}
+
+	private async initialize(redisUrl?: string): Promise<void> {
+		if (this.isInitializing) {
+			return;
+		}
+
+		this.isInitializing = true;
+		const connectionOptions = redisUrl
+			? { url: redisUrl }
+			: { host: 'localhost', port: 6379 };
+
+		try {
+			await this.verifyRedisConnection(redisUrl);
+
+			this.queue = new Queue<EscalationJobData>('escalation-notifications', {
+				connection: connectionOptions,
+				defaultJobOptions: {
+					removeOnComplete: 50,
+					removeOnFail: 50,
+				},
+			});
+
+			this.worker = new Worker<EscalationJobData>(
+				'escalation-notifications',
+				this.processEscalationJob.bind(this),
+				{
+					connection: connectionOptions,
+					concurrency: 5,
+				}
+			);
+
+			this.queue.on('error', (error) => {
+				this.logger.warn({
+					message: 'Escalation queue error',
+					service: SERVICE_NAME,
+					method: 'queue.error',
+					details: {
+						error: error instanceof Error ? error.message : String(error),
+					},
+				});
+				this.redisAvailable = false;
+			});
+
+			this.worker.on('error', (error) => {
+				this.logger.warn({
+					message: 'Escalation worker error',
+					service: SERVICE_NAME,
+					method: 'worker.error',
+					details: {
+						error: error instanceof Error ? error.message : String(error),
+					},
+				});
+				this.redisAvailable = false;
+			});
+
+			this.worker.on('completed', (job) => {
+				this.logger.info({
+					message: `Escalation: Monitor ${job.data.monitorId} still down`,
+					service: SERVICE_NAME,
+					method: 'worker.completed',
+					details: {
+						jobId: job.id,
+					},
+				});
+			});
+
+			this.worker.on('failed', (job, err) => {
+				this.logger.error({
+					message: `Escalation: Monitor ${job?.data.monitorId} still down`,
+					service: SERVICE_NAME,
+					method: 'worker.failed',
+					details: {
+						jobId: job?.id,
+						error: err.message,
+					},
+				});
+			});
+
+			this.redisAvailable = true;
+			this.logger.info({
+				message: 'Escalation job queue initialized successfully',
+				service: SERVICE_NAME,
+				method: 'initialize',
+			});
+		} catch (error) {
+			this.redisAvailable = false;
+			this.logger.warn({
+				message: 'Redis not available - escalation notifications will be disabled',
+				service: SERVICE_NAME,
+				method: 'initialize',
+				details: {
+					error: error instanceof Error ? error.message : String(error),
+				},
+			});
+		} finally {
+			this.isInitializing = false;
+		}
+	}
+
+	private async verifyRedisConnection(redisUrl?: string): Promise<void> {
+		const redisOptions = redisUrl
+			? { url: redisUrl, maxRetriesPerRequest: 0, retryStrategy: null, connectTimeout: 2000 }
+			: { host: 'localhost', port: 6379, maxRetriesPerRequest: 0, retryStrategy: null, connectTimeout: 2000 };
+
+		const client = new (Redis as any)(redisOptions as any);
+		try {
+			await client.connect();
+			await client.ping();
+		} finally {
+			await client.quit().catch(() => undefined);
+		}
+	}
+
+	/**
+	 * Schedules an escalation notification job to run after the specified delay
+	 */
+	async scheduleEscalation(monitorId: string, teamId: string, delayMinutes: number, notificationIds: string[]): Promise<void> {
+		if (notificationIds.length === 0) {
+			this.logger.warn({
+				message: `No notification IDs provided for escalation of monitor ${monitorId}`,
+				service: SERVICE_NAME,
+				method: 'scheduleEscalation',
+			});
+			return;
+		}
+
+		if (!this.redisAvailable || !this.queue) {
+			// Fallback to setTimeout if Redis is not available
+			this.logger.warn({
+				message: `Redis not available - using setTimeout for escalation scheduling for monitor ${monitorId}`,
+				service: SERVICE_NAME,
+				method: 'scheduleEscalation',
+				details: {
+					monitorId,
+					teamId,
+					delayMinutes,
+					notificationCount: notificationIds.length,
+				},
+			});
+			const delayMs = delayMinutes * 60 * 1000;
+			setTimeout(async () => {
+				try {
+					await this.processEscalationJob({
+						data: {
+							monitorId,
+							teamId,
+							notificationIds,
+						},
+					} as Job<EscalationJobData>);
+				} catch (error) {
+					this.logger.error({
+						message: `Error processing escalation job for monitor ${monitorId}`,
+						service: SERVICE_NAME,
+						method: 'scheduleEscalation',
+						details: {
+							error: error instanceof Error ? error.message : String(error),
+						},
+					});
+				}
+			}, delayMs);
+			return;
+		}
+
+		const delayMs = delayMinutes * 60 * 1000; // Convert minutes to milliseconds
+
+		try {
+			await this.queue.add(
+				'send-escalation',
+				{
+					monitorId,
+					teamId,
+					notificationIds,
+				},
+				{
+					delay: delayMs,
+					jobId: `escalation-${monitorId}-${Date.now()}`, // Unique job ID
+				}
+			);
+
+			this.logger.info({
+				message: `Scheduled escalation notification for monitor ${monitorId} in ${delayMinutes} minutes`,
+				service: SERVICE_NAME,
+				method: 'scheduleEscalation',
+				details: {
+					monitorId,
+					teamId,
+					delayMinutes,
+					notificationCount: notificationIds.length,
+				},
+			});
+		} catch (error) {
+			this.logger.error({
+				message: `Failed to schedule escalation for monitor ${monitorId}`,
+				service: SERVICE_NAME,
+				method: 'scheduleEscalation',
+				details: {
+					error: error instanceof Error ? error.message : String(error),
+				},
+			});
+			throw error;
+		}
+	}
+
+	/**
+	 * Processes escalation jobs by sending notifications to the specified channels
+	 */
+	private async processEscalationJob(job: Job<EscalationJobData>): Promise<void> {
+		const { monitorId, teamId, notificationIds } = job.data;
+
+		try {
+			this.logger.info({
+				message: `Processing escalation notification for monitor ${monitorId}`,
+				service: SERVICE_NAME,
+				method: 'processEscalationJob',
+				details: {
+					monitorId,
+					teamId,
+					notificationCount: notificationIds.length,
+				},
+			});
+
+			// Get monitor details
+			const monitor = await this.monitorsRepository.findById(monitorId, teamId);
+			if (!monitor) {
+				this.logger.warn({
+					message: `Monitor ${monitorId} not found during escalation processing`,
+					service: SERVICE_NAME,
+					method: 'processEscalationJob',
+				});
+				return;
+			}
+
+			// Skip escalation if the monitor has recovered before the escalation fired
+			if (monitor.status !== 'down') {
+				this.logger.info({
+					message: `Skipping escalation for monitor ${monitorId} because monitor status is no longer down`,
+					service: SERVICE_NAME,
+					method: 'processEscalationJob',
+					details: { monitorStatus: monitor.status },
+				});
+				return;
+			}
+
+			// Filter out escalation notification IDs that are also used for regular monitor notifications
+			// This ensures escalation emails only go to escalation-specific recipients, not regular recipients
+			const regularNotificationIds = monitor.notifications ?? [];
+			const escalationOnlyNotificationIds = notificationIds.filter(
+				(notificationId) => !regularNotificationIds.includes(notificationId)
+			);
+
+			if (escalationOnlyNotificationIds.length === 0) {
+				this.logger.info({
+					message: `No escalation-specific notifications to send for monitor ${monitorId} (all escalation notifications are also regular notifications)`,
+					service: SERVICE_NAME,
+					method: 'processEscalationJob',
+				});
+				return;
+			}
+
+			// Send notifications to escalation-specific channels only
+			const sendPromises = escalationOnlyNotificationIds.map(async (notificationId) => {
+				try {
+					await this.notificationsService.sendNotification(
+						teamId,
+						notificationId,
+						'monitor_escalation',
+						{
+							monitorId,
+							monitorName: monitor.name,
+							monitorUrl: monitor.url,
+							escalationDelay: 'delayed notification',
+						}
+					);
+					return true;
+				} catch (error) {
+					this.logger.error({
+						message: `Failed to send escalation notification for monitor ${monitorId}`,
+						service: SERVICE_NAME,
+						method: 'processEscalationJob',
+						details: {
+							monitorId,
+							teamId,
+							notificationId: notificationId,
+							error: error instanceof Error ? error.message : String(error),
+						},
+					});
+					return false;
+				}
+			});
+
+			const results = await Promise.all(sendPromises);
+			const successCount = results.filter(Boolean).length;
+			const failCount = results.length - successCount;
+
+			if (failCount > 0) {
+				this.logger.warn({
+					message: `Escalation completed with ${successCount} successes and ${failCount} failures for monitor ${monitorId}`,
+					service: SERVICE_NAME,
+					method: 'processEscalationJob',
+				});
+			} else {
+				this.logger.info({
+					message: `Escalation notifications sent successfully to ${successCount} escalation-specific channels for monitor ${monitorId}`,
+					service: SERVICE_NAME,
+					method: 'processEscalationJob',
+				});
+			}
+		} catch (error) {
+			this.logger.error({
+				message: `Failed to process escalation job for monitor ${monitorId}`,
+				service: SERVICE_NAME,
+				method: 'processEscalationJob',
+				details: {
+					error: error instanceof Error ? error.message : String(error),
+				},
+			});
+			throw error;
+		}
+	}
+
+	/**
+	 * Shuts down the queue and worker gracefully
+	 */
+	async shutdown(): Promise<void> {
+		this.logger.info({
+			message: 'Shutting down escalation job queue',
+			service: SERVICE_NAME,
+			method: 'shutdown',
+		});
+
+		if (this.worker) {
+			await this.worker.close();
+		}
+		if (this.queue) {
+			await this.queue.close();
+		}
+	}
+}

--- a/server/src/service/infrastructure/escalationJobQueue.ts
+++ b/server/src/service/infrastructure/escalationJobQueue.ts
@@ -285,24 +285,8 @@ export class EscalationJobQueue implements IEscalationJobQueue {
 				return;
 			}
 
-			// Filter out escalation notification IDs that are also used for regular monitor notifications
-			// This ensures escalation emails only go to escalation-specific recipients, not regular recipients
-			const regularNotificationIds = monitor.notifications ?? [];
-			const escalationOnlyNotificationIds = notificationIds.filter(
-				(notificationId) => !regularNotificationIds.includes(notificationId)
-			);
-
-			if (escalationOnlyNotificationIds.length === 0) {
-				this.logger.info({
-					message: `No escalation-specific notifications to send for monitor ${monitorId} (all escalation notifications are also regular notifications)`,
-					service: SERVICE_NAME,
-					method: 'processEscalationJob',
-				});
-				return;
-			}
-
-			// Send notifications to escalation-specific channels only
-			const sendPromises = escalationOnlyNotificationIds.map(async (notificationId) => {
+			// Send notifications to all configured escalation channels
+			const sendPromises = notificationIds.map(async (notificationId) => {
 				try {
 					await this.notificationsService.sendNotification(
 						teamId,
@@ -344,7 +328,7 @@ export class EscalationJobQueue implements IEscalationJobQueue {
 				});
 			} else {
 				this.logger.info({
-					message: `Escalation notifications sent successfully to ${successCount} escalation-specific channels for monitor ${monitorId}`,
+					message: `Escalation notifications sent successfully for monitor ${monitorId}`,
 					service: SERVICE_NAME,
 					method: 'processEscalationJob',
 				});

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -53,6 +53,11 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	}
 
 	private determineNotificationType(decision: MonitorActionDecision, monitor: Monitor): NotificationType {
+		// Escalation notifications have highest priority
+		if (decision.notificationReason === "escalation") {
+			return "monitor_escalation";
+		}
+
 		// Down status has highest priority (critical)
 		if (monitor.status === "down") {
 			return "monitor_down";
@@ -80,6 +85,7 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	private determineSeverity(type: NotificationType): NotificationSeverity {
 		switch (type) {
 			case "monitor_down":
+			case "monitor_escalation":
 				return "critical";
 			case "threshold_breach":
 				return "warning";
@@ -97,6 +103,8 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		switch (type) {
 			case "monitor_down":
 				return this.buildMonitorDownContent(monitor, monitorStatusResponse);
+			case "monitor_escalation":
+				return this.buildMonitorEscalationContent(monitor, monitorStatusResponse);
 			case "monitor_up":
 				return this.buildMonitorUpContent(monitor);
 			case "threshold_breach":
@@ -121,6 +129,29 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		// Add error message if available
 		if (monitorStatusResponse.message) {
 			details.push(`Error: ${monitorStatusResponse.message}`);
+		}
+
+		return {
+			title,
+			summary,
+			details,
+			timestamp: new Date(),
+		};
+	}
+
+	private buildMonitorEscalationContent(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): NotificationContent {
+		const title = `Escalation: Monitor ${monitor.name} still down`;
+		const summary = `Monitor "${monitor.name}" has been down for an extended period and requires immediate attention. This is an escalation notification.`;
+		const details = [`URL: ${monitor.url}`, `Status: Still Down (Escalated)`, `Type: ${monitor.type}`, `Priority: HIGH - Escalation Triggered`];
+
+		// Add escalation delay info if available
+		if (monitorStatusResponse.message && monitorStatusResponse.message !== "Escalation notification") {
+			details.push(`Escalation Delay: ${monitorStatusResponse.message}`);
+		}
+
+		// Add response code if available
+		if (monitorStatusResponse.code) {
+			details.push(`Last Response Code: ${monitorStatusResponse.code}`);
 		}
 
 		return {

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -5,11 +5,13 @@ import { buildTestEmail } from "@/service/infrastructure/notificationProviders/u
 import type { NotificationMessage } from "@/types/notificationMessage.js";
 import type { ILogger } from "@/utils/logger.js";
 import { IEmailService } from "@/service/infrastructure/emailService.js";
+import { ISettingsService } from "@/service/system/settingsService.js";
+
 export class EmailProvider implements INotificationProvider {
 	private emailService: IEmailService;
 	private logger: ILogger;
 
-	constructor(emailService: IEmailService, logger: ILogger) {
+	constructor(emailService: IEmailService, logger: ILogger, settingsService: ISettingsService) {
 		this.emailService = emailService;
 		this.logger = logger;
 	}
@@ -81,6 +83,8 @@ export class EmailProvider implements INotificationProvider {
 		switch (message.type) {
 			case "monitor_down":
 				return `Monitor ${message.monitor.name} is down`;
+			case "monitor_escalation":
+				return `Escalation: Monitor ${message.monitor.name} is still down`;
 			case "monitor_up":
 				return `Monitor ${message.monitor.name} is back up`;
 			case "threshold_breach":

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -6,6 +6,7 @@ import type { MonitorActionDecision } from "@/service/infrastructure/SuperSimple
 import type { ISettingsService } from "@/service/system/settingsService.js";
 import { ILogger } from "@/utils/logger.js";
 import type { INotificationMessageBuilder } from "@/service/infrastructure/notificationMessageBuilder.js";
+import type { IEscalationJobQueue } from "./escalationJobQueue.js";
 
 export interface INotificationsService {
 	createNotification: (notificationData: Partial<Notification>, userId: string, teamId: string) => Promise<Notification>;
@@ -14,6 +15,7 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	sendNotification: (teamId: string, notificationId: string, type: string, data: any) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -36,6 +38,7 @@ export class NotificationsService implements INotificationsService {
 	private logger: ILogger;
 	private settingsService: ISettingsService;
 	private notificationMessageBuilder: INotificationMessageBuilder;
+	private escalationJobQueue: IEscalationJobQueue | null;
 
 	constructor(
 		notificationsRepository: INotificationsRepository,
@@ -49,7 +52,8 @@ export class NotificationsService implements INotificationsService {
 		teamsProvider: INotificationProvider,
 		settingsService: ISettingsService,
 		logger: ILogger,
-		notificationMessageBuilder: INotificationMessageBuilder
+		notificationMessageBuilder: INotificationMessageBuilder,
+		escalationJobQueue?: IEscalationJobQueue
 	) {
 		this.notificationsRepository = notificationsRepository;
 		this.monitorsRepository = monitorsRepository;
@@ -63,6 +67,7 @@ export class NotificationsService implements INotificationsService {
 		this.settingsService = settingsService;
 		this.logger = logger;
 		this.notificationMessageBuilder = notificationMessageBuilder;
+		this.escalationJobQueue = escalationJobQueue || null;
 	}
 
 	private send = async (
@@ -137,8 +142,111 @@ export class NotificationsService implements INotificationsService {
 			return false;
 		}
 
-		// Send notifications based on decision
-		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+		// Send immediate notifications based on decision
+		const immediateResult = await this.sendNotifications(monitor, monitorStatusResponse, decision);
+
+		// Schedule escalation notifications if monitor went down and has escalation configurations
+		if (monitor.status === "down" && monitor.escalations && monitor.escalations.notificationIds.length > 0 && this.escalationJobQueue) {
+			try {
+				this.logger.info({
+					message: `[NOTIFICATION DEBUG] Scheduling escalations for monitor ${monitor.id}`,
+					service: SERVICE_NAME,
+					method: "handleNotifications",
+					details: {
+						escalationDelay: monitor.escalations.delayMinutes,
+						escalationNotificationIds: monitor.escalations.notificationIds,
+					},
+				});
+				await this.scheduleEscalationNotifications(monitor, monitorStatusResponse);
+			} catch (error: unknown) {
+				this.logger.error({
+					message: `Error scheduling escalation notifications for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+					service: SERVICE_NAME,
+					method: "handleNotifications",
+					stack: error instanceof Error ? error.stack : undefined,
+				});
+			}
+		}
+
+		return immediateResult;
+	};
+
+	sendNotification = async (teamId: string, notificationId: string, type: string, data: any) => {
+		const notification = await this.notificationsRepository.findById(notificationId, teamId);
+		if (!notification) {
+			this.logger.warn({
+				message: `Notification ${notificationId} not found`,
+				service: SERVICE_NAME,
+				method: "sendNotification",
+			});
+			return false;
+		}
+
+		// Get the monitor from the repository
+		const monitor = await this.monitorsRepository.findById(data.monitorId, teamId);
+		if (!monitor) {
+			this.logger.warn({
+				message: `Monitor ${data.monitorId} not found`,
+				service: SERVICE_NAME,
+				method: "sendNotification",
+			});
+			return false;
+		}
+
+		// Create a mock monitor status response for escalation notifications
+		const monitorStatusResponse = {
+			monitorId: data.monitorId,
+			teamId,
+			type: monitor.type,
+			status: false,
+			code: 0,
+			message: data.escalationDelay || "Escalation notification",
+		};
+
+		const decision: MonitorActionDecision = {
+			shouldCreateIncident: false,
+			shouldResolveIncident: false,
+			shouldSendNotification: true,
+			incidentReason: null,
+			notificationReason: type === "monitor_escalation" ? "escalation" : "status_change",
+		};
+
+		// Build notification message
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+		const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, decision, clientHost);
+
+		return this.send(notification, monitor, monitorStatusResponse, decision, notificationMessage);
+	};
+
+	private scheduleEscalationNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse) => {
+		if (!this.escalationJobQueue) {
+			this.logger.warn({
+				message: "Escalation job queue not available, skipping escalation scheduling",
+				service: SERVICE_NAME,
+				method: "scheduleEscalationNotifications",
+			});
+			return;
+		}
+
+		if (monitor.escalations.notificationIds.length === 0) {
+			return;
+		}
+
+		this.logger.info({
+			message: `Scheduling escalation notification for monitor ${monitor.id} with ${monitor.escalations.delayMinutes} minute delay`,
+			service: SERVICE_NAME,
+			method: "scheduleEscalationNotifications",
+			details: { escalationDelay: monitor.escalations.delayMinutes, notificationIds: monitor.escalations.notificationIds },
+		});
+
+		// Schedule escalation job for this monitor's escalation configuration
+		await this.escalationJobQueue.scheduleEscalation(
+			monitor.id,
+			monitor.teamId,
+			monitor.escalations.delayMinutes,
+			monitor.escalations.notificationIds
+		);
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/service/infrastructure/statusService.ts
+++ b/server/src/service/infrastructure/statusService.ts
@@ -236,13 +236,14 @@ export class StatusService implements IStatusService {
 			let newStatus: MonitorStatus = status === true ? "up" : "down";
 			let statusChanged = false;
 
-			// Return early if not enough data points
 			if (monitor.statusWindow.length < monitor.statusWindowSize) {
+				// Check if this is a recovery from down/breached state
+				const isRecovery = (prevStatus === "down" || prevStatus === "breached") && newStatus === "up";
 				monitor.status = newStatus;
 				const updated = await this.monitorsRepository.updateById(monitor.id, monitor.teamId, monitor);
 				return {
 					monitor: updated,
-					statusChanged: false,
+					statusChanged: isRecovery,
 					prevStatus,
 					code,
 					timestamp: Date.now(),

--- a/server/src/shutdown.ts
+++ b/server/src/shutdown.ts
@@ -16,6 +16,7 @@ export const initShutdownListener = (server: Server, services: InitializedServic
 
 		try {
 			server.close();
+			await services.escalationJobQueue.shutdown();
 			await services.jobQueue.shutdown();
 			await services.db.disconnect();
 			logger.info({ message: "Graceful shutdown complete" });

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface MonitorEscalation {
+	delayMinutes: number;
+	notificationIds: string[];
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +42,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalations: MonitorEscalation;
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/types/notificationMessage.ts
+++ b/server/src/types/notificationMessage.ts
@@ -3,7 +3,7 @@
  * Part of notification system unification effort
  */
 
-export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test";
+export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "monitor_escalation" | "test";
 
 export type NotificationSeverity = "critical" | "warning" | "info" | "success";
 

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -67,6 +67,7 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalations: z.object({delayMinutes: z.number().min(0, "Delay must be at least 0"), notificationIds: z.array(z.string()),}).optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +90,12 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalations: z
+		.object({
+			delayMinutes: z.number().min(0, "Delay must be at least 0"),
+			notificationIds: z.array(z.string()),
+		})
+		.optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),
@@ -156,6 +163,12 @@ const importedMonitorSchema = z.object({
 	selectedDisks: z.array(z.string()).default([]),
 	gameId: z.union([z.string(), z.literal("")]).optional(),
 	grpcServiceName: z.union([z.string(), z.literal("")]).default(""),
+	escalations: z
+		.object({
+			delayMinutes: z.number().min(0, "Delay must be at least 0").default(0),
+			notificationIds: z.array(z.string()).default([]),
+		})
+		.default({ delayMinutes: 0, notificationIds: [] }),
 	group: z.union([z.string().max(50).trim(), z.null()]).default(null),
 	geoCheckEnabled: z.boolean().default(false),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).default([]),


### PR DESCRIPTION
## Describe your changes

Implemented escalated notifications where user can select time period for when to send an escalated email to specified channel after a monitor has been down for the specified amount of time. 

- Modified ../CreateMonitor/Index.tsx, ../Hooks/useMonitor.ts, ../Validation/monitor.ts, ../Types/Monitor.ts, and ../locales/en.js in the client directory to implement the new monitor configuration component and support the new escalation notification type along with the English translation.
- Modified the following files to implement backend handling of new notification type, persist configuration inputs, and support escalation notification.:
- server/src/config/services.ts, server/src/db/models/Monitor.ts, server/src/repositories/monitors/MongoMonitorsRepository.ts, server/src/service/index.ts, server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts, server/src/service/infrastructure/notificationMessageBuilder.ts, server/src/service/infrastructure/notificationProviders/email.ts
- Created the escalationJobQueue.ts file to handle queueing and sending escalation notifications.


Fixes #1 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x]  I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

