### PR TITLE
feat: add escalated notifications for persistent incidents

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -17,6 +17,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,
 	geoCheckLocations: data?.geoCheckLocations || [],
 	geoCheckInterval: data?.geoCheckInterval || 300000,
+	escalations: data?.escalations || [],
 });
 
 export const useMonitorForm = ({

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -698,6 +698,77 @@ const CreateMonitorPage = () => {
 			/>
 
 			<ConfigBox
+				title="Escalated notifications"
+				subtitle="Send additional alerts to the configured notification channels after the monitor has been down for the specified durations. Useful for ensuring incidents are escalated as they persist."
+				rightContent={
+					<Controller
+						name="escalations"
+						control={control}
+						render={({ field, fieldState }) => {
+							const value: { delayMinutes: number }[] = (field.value as { delayMinutes: number }[] | undefined) ?? [];
+							return (
+								<Stack spacing={theme.spacing(LAYOUT.MD)}>
+									{value.length === 0 && (
+										<Typography color="text.secondary">
+											No escalations configured. Click &quot;Add escalation&quot; to add one.
+										</Typography>
+									)}
+									{value.map((escalation, index) => (
+										<Stack
+											key={index}
+											direction="row"
+											alignItems="center"
+											spacing={theme.spacing(SPACING.LG)}
+										>
+											<TextField
+												type="number"
+												fieldLabel={`Escalation #${index + 1} delay (minutes)`}
+												value={String(escalation.delayMinutes)}
+												onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+													const next = [...value];
+													const parsed = Number(e.target.value);
+													next[index] = {
+														delayMinutes: Number.isNaN(parsed) ? 0 : parsed,
+													};
+													field.onChange(next);
+												}}
+												fullWidth
+											/>
+											<IconButton
+												size="small"
+												onClick={() => {
+													field.onChange(value.filter((_, i) => i !== index));
+												}}
+												aria-label="Remove escalation"
+											>
+												<Trash2 size={16} />
+											</IconButton>
+										</Stack>
+									))}
+									{fieldState.error && (
+										<Typography color="error" variant="caption">
+											{Array.isArray(fieldState.error)
+												? "Each escalation must have a valid delay (≥ 1 minute)"
+												: fieldState.error.message}
+										</Typography>
+									)}
+									<Button
+										variant="outlined"
+										color="primary"
+										onClick={() => {
+											field.onChange([...value, { delayMinutes: 5 }]);
+										}}
+									>
+										Add escalation
+									</Button>
+								</Stack>
+							);
+						}}
+					/>
+				}
+			/>
+
+			<ConfigBox
 				title={t("pages.createMonitor.form.notifications.title")}
 				subtitle={t("pages.createMonitor.form.notifications.description")}
 				rightContent={

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,10 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface MonitorEscalation {
+	delayMinutes: number;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -76,6 +80,7 @@ export interface Monitor {
 	geoCheckEnabled?: boolean;
 	geoCheckLocations?: GeoContinent[];
 	geoCheckInterval?: number;
+	escalations?: MonitorEscalation[];
 	recentChecks: CheckSnapshot[];
 	createdAt: string;
 	updatedAt: string;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -4,6 +4,14 @@ import { GeoContinents } from "@/Types/GeoCheck";
 // URL schema with custom error message
 const urlSchema = z.url({ message: "Please enter a valid URL" });
 
+// Escalation schema
+const escalationSchema = z.object({
+	delayMinutes: z
+		.number({ message: "Delay must be a number" })
+		.min(1, "Escalation delay must be at least 1 minute")
+		.max(10080, "Escalation delay must be at most 7 days (10080 minutes)"),
+});
+
 // Common base schema for all monitor types
 const baseSchema = z.object({
 	name: z
@@ -27,6 +35,7 @@ const baseSchema = z.object({
 		.number()
 		.min(300000, "Interval must be at least 5 minutes")
 		.optional(),
+	escalations: z.array(escalationSchema).optional(),
 });
 
 // HTTP monitor schema

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -72,6 +72,10 @@ const IncidentSchema = new Schema<IncidentDocument>(
 			type: String,
 			default: null,
 		},
+		firedEscalations: {
+			type: [Number],
+			default: [],
+		},
 	},
 	{ timestamps: true }
 );

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -1,5 +1,5 @@
 import { Schema, model, Types } from "mongoose";
-import type { Monitor, MonitorMatchMethod, CheckSnapshot } from "@/types/monitor.js";
+import type { Monitor, MonitorMatchMethod, CheckSnapshot, MonitorEscalation } from "@/types/monitor.js";
 import { MonitorTypes, MonitorStatuses } from "@/types/monitor.js";
 import type {
 	CheckAudits,
@@ -169,6 +169,13 @@ const snapshotAuditsSchema = new Schema<CheckAudits>(
 		fcp: { type: snapshotLighthouseAuditSchema },
 		lcp: { type: snapshotLighthouseAuditSchema },
 		tbt: { type: snapshotLighthouseAuditSchema },
+	},
+	{ _id: false }
+);
+
+const escalationSchema = new Schema<MonitorEscalation>(
+	{
+		delayMinutes: { type: Number, required: true, min: 1 },
 	},
 	{ _id: false }
 );
@@ -350,6 +357,10 @@ const MonitorSchema = new Schema<MonitorDocument>(
 		geoCheckInterval: {
 			type: Number,
 			default: 300000,
+		},
+		escalations: {
+			type: [escalationSchema],
+			default: [],
 		},
 		recentChecks: {
 			type: [checkSnapshotSchema],

--- a/server/src/repositories/incidents/MongoIncidentRepository.ts
+++ b/server/src/repositories/incidents/MongoIncidentRepository.ts
@@ -60,6 +60,7 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			resolvedBy: doc.resolvedBy ? this.toStringId(doc.resolvedBy) : null,
 			resolvedByEmail: doc.resolvedByEmail ?? null,
 			comment: doc.comment ?? null,
+			firedEscalations: doc.firedEscalations ?? [],
 			createdAt: this.toDateString(doc.createdAt),
 			updatedAt: this.toDateString(doc.updatedAt),
 		};

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -391,6 +391,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalations: (doc.escalations ?? []).map((e) => ({ delayMinutes: e.delayMinutes })),
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};
@@ -450,6 +451,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalations: (doc.escalations ?? []).map((e) => ({ delayMinutes: e.delayMinutes })),
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -177,6 +177,18 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 						stack: error instanceof Error ? error.stack : undefined,
 					});
 				});
+
+				// Step 8. Handle escalated notifications when monitor is currently down
+				if (statusChangeResult.monitor.status === "down" && (statusChangeResult.monitor.escalations?.length ?? 0) > 0) {
+					this.handleEscalations(statusChangeResult.monitor).catch((error: unknown) => {
+						this.logger.warn({
+							message: `Error handling escalations for monitor ${statusChangeResult.monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+							service: SERVICE_NAME,
+							method: "getMonitorJob",
+							stack: error instanceof Error ? error.stack : undefined,
+						});
+					});
+				}
 			} catch (error: unknown) {
 				this.logger.warn({
 					message: error instanceof Error ? error.message : "Unknown error",
@@ -417,6 +429,47 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 			}
 		};
 	};
+
+	private async handleEscalations(monitor: Monitor): Promise<void> {
+		const escalations = monitor.escalations ?? [];
+		if (escalations.length === 0) return;
+
+		const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId);
+		if (!activeIncident) return;
+
+		const startTime = new Date(activeIncident.startTime);
+		const elapsedMs = Date.now() - startTime.getTime();
+		const fired = new Set<number>(activeIncident.firedEscalations ?? []);
+
+		const newlyFired: number[] = [];
+		for (const escalation of escalations) {
+			const requiredMs = escalation.delayMinutes * 60 * 1000;
+			if (elapsedMs >= requiredMs && !fired.has(escalation.delayMinutes)) {
+				try {
+					await this.notificationsService.sendEscalationNotifications(monitor, escalation.delayMinutes, startTime);
+					newlyFired.push(escalation.delayMinutes);
+					fired.add(escalation.delayMinutes);
+				} catch (error: unknown) {
+					this.logger.warn({
+						message: `Failed to send escalation (${escalation.delayMinutes}m) for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+						service: SERVICE_NAME,
+						method: "handleEscalations",
+					});
+				}
+			}
+		}
+
+		if (newlyFired.length > 0) {
+			await this.incidentsRepository.updateById(activeIncident.id, activeIncident.teamId, {
+				firedEscalations: Array.from(fired),
+			});
+			this.logger.info({
+				message: `Fired ${newlyFired.length} escalation(s) for monitor ${monitor.id}: ${newlyFired.join(", ")} minute(s)`,
+				service: SERVICE_NAME,
+				method: "handleEscalations",
+			});
+		}
+	}
 
 	private evaluateMonitorAction(statusChangeResult: StatusChangeResult): MonitorActionDecision {
 		const { monitor, statusChanged, prevStatus } = statusChangeResult;

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -15,6 +15,7 @@ export interface INotificationMessageBuilder {
 		decision: MonitorActionDecision,
 		clientHost: string
 	): NotificationMessage;
+	buildEscalationMessage(monitor: Monitor, delayMinutes: number, incidentStartTime: Date, clientHost: string): NotificationMessage;
 	extractThresholdBreaches(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): ThresholdBreach[];
 }
 
@@ -77,9 +78,47 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		return "monitor_up";
 	}
 
+	buildEscalationMessage(monitor: Monitor, delayMinutes: number, incidentStartTime: Date, clientHost: string): NotificationMessage {
+		const elapsedMinutes = Math.max(0, Math.round((Date.now() - incidentStartTime.getTime()) / 60000));
+		const title = `[ESCALATION] Monitor Still Down: ${monitor.name}`;
+		const summary = `Monitor "${monitor.name}" has been down for approximately ${elapsedMinutes} minute(s). Escalation triggered after ${delayMinutes} minute(s).`;
+		const details = [
+			`URL: ${monitor.url}`,
+			`Status: Down`,
+			`Type: ${monitor.type}`,
+			`Incident started: ${incidentStartTime.toISOString()}`,
+			`Escalation delay: ${delayMinutes} minute(s)`,
+			`Time since incident start: ${elapsedMinutes} minute(s)`,
+		];
+
+		return {
+			type: "monitor_escalation",
+			severity: "critical",
+			monitor: {
+				id: monitor.id,
+				name: monitor.name,
+				url: monitor.url,
+				type: monitor.type,
+				status: monitor.status,
+			},
+			content: {
+				title,
+				summary,
+				details,
+				timestamp: new Date(),
+			},
+			clientHost,
+			metadata: {
+				teamId: monitor.teamId,
+				notificationReason: "escalation",
+			},
+		};
+	}
+
 	private determineSeverity(type: NotificationType): NotificationSeverity {
 		switch (type) {
 			case "monitor_down":
+			case "monitor_escalation":
 				return "critical";
 			case "threshold_breach":
 				return "warning";

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -87,6 +87,8 @@ export class EmailProvider implements INotificationProvider {
 				return `Monitor ${message.monitor.name} threshold exceeded`;
 			case "threshold_resolved":
 				return `Monitor ${message.monitor.name} thresholds resolved`;
+			case "monitor_escalation":
+				return `[ESCALATION] Monitor ${message.monitor.name} is still down`;
 			default:
 				return `Alert: ${message.monitor.name}`;
 		}

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,6 +14,7 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	sendEscalationNotifications: (monitor: Monitor, delayMinutes: number, incidentStartTime: Date) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -139,6 +140,43 @@ export class NotificationsService implements INotificationsService {
 
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	sendEscalationNotifications = async (monitor: Monitor, delayMinutes: number, incidentStartTime: Date): Promise<boolean> => {
+		const notificationIds = monitor.notifications ?? [];
+		if (notificationIds.length === 0) {
+			return false;
+		}
+		const notifications = await this.notificationsRepository.findNotificationsByIds(notificationIds);
+
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+		const notificationMessage = this.notificationMessageBuilder.buildEscalationMessage(monitor, delayMinutes, incidentStartTime, clientHost);
+
+		// Reuse the existing send pipeline by constructing a synthetic decision
+		const escalationDecision: MonitorActionDecision = {
+			shouldCreateIncident: false,
+			shouldResolveIncident: false,
+			shouldSendNotification: true,
+			incidentReason: null,
+			notificationReason: "status_change",
+		};
+
+		// Use a minimal monitorStatusResponse — providers consume the prebuilt notificationMessage
+		const tasks = notifications.map((notification) =>
+			this.send(notification, monitor, { code: 0 } as MonitorStatusResponse, escalationDecision, notificationMessage)
+		);
+		const outcomes = await Promise.all(tasks);
+		const succeeded = outcomes.filter(Boolean).length;
+		const failed = outcomes.length - succeeded;
+		if (failed > 0) {
+			this.logger.warn({
+				message: `Escalation send completed with ${succeeded} success, ${failed} failure(s) for monitor ${monitor.id}`,
+				service: SERVICE_NAME,
+				method: "sendEscalationNotifications",
+			});
+		}
+		return succeeded === notifications.length;
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -16,6 +16,7 @@ export interface Incident {
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;
 	comment?: string | null;
+	firedEscalations?: number[];
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,10 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface MonitorEscalation {
+	delayMinutes: number;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -53,6 +57,7 @@ export interface Monitor {
 	geoCheckEnabled?: boolean;
 	geoCheckLocations?: GeoContinent[];
 	geoCheckInterval?: number;
+	escalations?: MonitorEscalation[];
 	recentChecks: CheckSnapshot[];
 	createdAt: string;
 	updatedAt: string;

--- a/server/src/types/notificationMessage.ts
+++ b/server/src/types/notificationMessage.ts
@@ -3,7 +3,7 @@
  * Part of notification system unification effort
  */
 
-export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test";
+export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test" | "monitor_escalation";
 
 export type NotificationSeverity = "critical" | "warning" | "info" | "success";
 

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -3,6 +3,10 @@ import { booleanCoercion } from "./shared.js";
 import { GeoContinents } from "@/types/geoCheck.js";
 import { MonitorMatchMethods, MonitorTypes } from "@/types/monitor.js";
 
+const escalationSchema = z.object({
+	delayMinutes: z.number().min(1, "Escalation delay must be at least 1 minute"),
+});
+
 export const getMonitorByIdParamValidation = z.object({
 	monitorId: z.string().min(1, "Monitor ID is required"),
 });
@@ -78,6 +82,7 @@ export const createMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalations: z.array(escalationSchema).optional(),
 });
 
 export const editMonitorBodyValidation = z.object({
@@ -107,6 +112,7 @@ export const editMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalations: z.array(escalationSchema).optional(),
 });
 
 export const pauseMonitorParamValidation = z.object({


### PR DESCRIPTION
## Summary

Adds support for **escalated notifications** — additional alerts that fire after a monitor has been down for user-defined durations. Rather than firing a single alert when a monitor first goes down, escalated alerts ensure the right people are notified as an incident persists.

Submitted as part of CEN3031 Mini Project (UF, Spring 2026).

## What's new

**Frontend** (monitor create/edit page)
- New "Escalated notifications" config box with add/remove rows
- Each row sets a delay in minutes; persists with the monitor and reloads correctly

**Backend**
- `Monitor.escalations: { delayMinutes: number }[]` — persisted on the monitor
- `Incident.firedEscalations: number[]` — per-incident tracking so each escalation fires at most once
- Heartbeat job evaluates due escalations on every check while the monitor is `down` and an active incident exists
- `NotificationsService.sendEscalationNotifications()` reuses the existing notification channel pipeline
- `NotificationMessageBuilder.buildEscalationMessage()` produces a dedicated `monitor_escalation` message
- Email provider routes the new message type to a `[ESCALATION] ...` subject line

## How it works

1. User configures escalations on a monitor (e.g. `[2, 10, 30]` minutes).
2. When the monitor goes `down`, the existing initial alert fires immediately and an incident is opened.
3. On each subsequent heartbeat while the monitor is still down, the worker computes elapsed time since the incident started and fires any escalations whose delay has now elapsed and that haven't already fired (tracked on the incident).
4. When the monitor recovers, the incident is closed normally — fired escalation state is preserved on the resolved incident.

## Acceptance criteria
- [x] Escalated notification setting — frontend implementation
- [x] Escalated notification persists alongside the monitor and survives reload
- [x] Email notification sent according to the escalation schedule

## Test plan

- [ ] Create a monitor with two escalations (e.g. 2 min, 5 min) and at least one email notification
- [ ] Verify the config box persists the values after Save → reload
- [ ] Verify Cancel reverts unsaved changes
- [ ] Take the monitored service down; confirm initial down email
- [ ] Wait the escalation intervals; confirm escalation emails arrive
- [ ] Bring the service back up; confirm recovery email; confirm escalations are not re-fired on the next incident until their delays elapse again