### PR TITLE
Add feature for escalation notifications

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalationRules: data?.escalationRules || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useEffect } from "react";
 import { logger } from "@/Utils/logger";
 import { useParams, useLocation, useNavigate } from "react-router";
-import { useForm, Controller } from "react-hook-form";
+import { useForm, Controller, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTheme } from "@mui/material";
 import Stack from "@mui/material/Stack";
@@ -191,6 +191,10 @@ const CreateMonitorPage = () => {
 	);
 
 	const { data: notifications } = useGet<Notification[]>("/notifications/team");
+	const notificationOptions = (notifications ?? []).map((n) => ({
+		...n,
+		name: n.notificationName,
+	}));
 	const { data: games } = useGet<GamesMap>("/monitors/games");
 
 	const { schema, defaults } = useMonitorForm({
@@ -203,6 +207,10 @@ const CreateMonitorPage = () => {
 		defaultValues: defaults,
 	});
 	const { control, watch, handleSubmit, clearErrors } = form;
+	const { fields: escalationRuleFields, append, remove } = useFieldArray({
+		control,
+		name: "escalationRules",
+	});
 
 	useEffect(() => {
 		form.reset(defaults);
@@ -705,11 +713,6 @@ const CreateMonitorPage = () => {
 						name="notifications"
 						control={control}
 						render={({ field }) => {
-							// Map notifications to have 'name' property for Autocomplete
-							const notificationOptions = (notifications ?? []).map((n) => ({
-								...n,
-								name: n.notificationName,
-							}));
 							const selectedNotifications = notificationOptions.filter((n) =>
 								(field.value ?? []).includes(n.id)
 							);
@@ -762,6 +765,86 @@ const CreateMonitorPage = () => {
 							);
 						}}
 					/>
+				}
+			/>
+
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalations.title")}
+				subtitle={t("pages.createMonitor.form.escalations.description")}
+				rightContent={
+					<Stack spacing={theme.spacing(LAYOUT.MD)}>
+						{escalationRuleFields.map((rule, index) => (
+							<Stack
+								key={rule.id}
+								direction="row"
+								alignItems="center"
+								spacing={theme.spacing(LAYOUT.MD)}
+								width="100%"
+							>
+								<Controller
+									name={`escalationRules.${index}.channelId`}
+									control={control}
+									render={({ field: channelField, fieldState }) => (
+										<Select
+											{...channelField}
+											value={channelField.value ?? ""}
+											fieldLabel={t(
+												"pages.createMonitor.form.escalations.option.channel.label"
+											)}
+											error={!!fieldState.error}
+											onChange={(event) => channelField.onChange(event.target.value)}
+										>
+											<MenuItem value="">
+												{t(
+													"pages.createMonitor.form.escalations.option.channel.placeholder"
+												)}
+											</MenuItem>
+											{notificationOptions.map((notification) => (
+												<MenuItem key={notification.id} value={notification.id}>
+													{notification.notificationName}
+												</MenuItem>
+											))}
+										</Select>
+									)}
+								/>
+
+								<Controller
+									name={`escalationRules.${index}.delayMinutes`}
+									control={control}
+									render={({ field: delayField, fieldState }) => (
+										<TextField
+											{...delayField}
+											type="number"
+											fieldLabel={t(
+												"pages.createMonitor.form.escalations.option.delay.label"
+											)}
+											error={!!fieldState.error}
+											helperText={fieldState.error?.message ?? ""}
+											fullWidth
+											inputProps={{ min: 1 }}
+										/>
+									)}
+								/>
+
+								<IconButton
+									size="small"
+									onClick={() => remove(index)}
+									aria-label={t(
+										"pages.createMonitor.form.escalations.removeRule"
+									)}
+								>
+									<Trash2 size={16} />
+								</IconButton>
+							</Stack>
+						))}
+
+						<Button
+							variant="outlined"
+							onClick={() => append({ channelId: "", delayMinutes: 5 })}
+						>
+							{t("pages.createMonitor.form.escalations.addRule")}
+						</Button>
+					</Stack>
 				}
 			/>
 

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,12 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface EscalationRule {
+	id: string;
+	channelId: string;
+	delayMinutes: number;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +66,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationRules?: EscalationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -5,6 +5,15 @@ import { GeoContinents } from "@/Types/GeoCheck";
 const urlSchema = z.url({ message: "Please enter a valid URL" });
 
 // Common base schema for all monitor types
+const escalationRuleSchema = z.object({
+	id: z.string().optional(),
+	channelId: z.string().min(1, "Notification channel is required"),
+	delayMinutes: z
+		.coerce.number({ message: "Delay must be at least 1 minute" })
+		.min(1, "Delay must be at least 1 minute")
+		.max(1440, "Delay cannot exceed 1440 minutes"),
+});
+
 const baseSchema = z.object({
 	name: z
 		.string()
@@ -13,6 +22,7 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalationRules: z.array(escalationRuleSchema).optional(),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -543,6 +543,20 @@
 					"description": "Select the notification channels you want to use",
 					"title": "Notifications"
 				},
+				"escalations": {
+					"description": "Configure escalation rules for delayed notifications when incidents remain unresolved",
+					"title": "Escalation Rules",
+					"addRule": "Add Rule",
+					"option": {
+						"delay": {
+							"label": "Delay before escalation (minutes)"
+						},
+						"channel": {
+							"label": "Escalation channel",
+							"placeholder": "Select a notification channel"
+						}
+					}
+				},
 				"type": {
 					"description": "Select the type of check to perform",
 					"optionDockerDescription": "Use Docker to monitor if a container is running.",

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -7,6 +7,7 @@ type IncidentDocumentBase = Omit<Incident, "id" | "monitorId" | "teamId" | "reso
 	resolvedBy?: Types.ObjectId | null;
 	startTime: Date;
 	endTime: Date | null;
+	escalationNotificationsSent: string[];
 	createdAt: Date;
 	updatedAt: Date;
 };
@@ -67,6 +68,10 @@ const IncidentSchema = new Schema<IncidentDocument>(
 		resolvedByEmail: {
 			type: String,
 			default: null,
+		},
+		escalationNotificationsSent: {
+			type: [String],
+			default: [],
 		},
 		comment: {
 			type: String,

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -16,6 +16,12 @@ import type {
 
 type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Date };
 
+type EscalationRuleDocument = {
+	id: string;
+	channelId: Types.ObjectId;
+	delayMinutes: number;
+};
+
 type MonitorDocumentBase = Omit<
 	Monitor,
 	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
@@ -24,6 +30,7 @@ type MonitorDocumentBase = Omit<
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
 	selectedDisks: string[];
+	escalationRules: EscalationRuleDocument[];
 	matchMethod?: MonitorMatchMethod;
 };
 
@@ -173,6 +180,15 @@ const snapshotAuditsSchema = new Schema<CheckAudits>(
 	{ _id: false }
 );
 
+const escalationRuleSchema = new Schema<EscalationRuleDocument>(
+	{
+		id: { type: String, required: true, default: () => new Types.ObjectId().toString() },
+		channelId: { type: String, ref: "Notification", required: true },
+		delayMinutes: { type: Number, required: true, min: 1 },
+	},
+	{ _id: false }
+);
+
 const checkSnapshotSchema = new Schema<CheckSnapshotDocument>(
 	{
 		id: { type: String, required: true },
@@ -284,6 +300,10 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalationRules: {
+			type: [escalationRuleSchema],
+			default: [],
+		},
 		secret: {
 			type: String,
 		},

--- a/server/src/repositories/incidents/MongoIncidentRepository.ts
+++ b/server/src/repositories/incidents/MongoIncidentRepository.ts
@@ -59,6 +59,7 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			resolutionType: doc.resolutionType ?? null,
 			resolvedBy: doc.resolvedBy ? this.toStringId(doc.resolvedBy) : null,
 			resolvedByEmail: doc.resolvedByEmail ?? null,
+			escalationNotificationsSent: doc.escalationNotificationsSent ?? [],
 			comment: doc.comment ?? null,
 			createdAt: this.toDateString(doc.createdAt),
 			updatedAt: this.toDateString(doc.updatedAt),

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -351,6 +351,11 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification) => toStringId(notification));
+		const escalationRules = (doc.escalationRules ?? []).map((rule) => ({
+			id: rule.id,
+			channelId: rule.channelId,
+			delayMinutes: rule.delayMinutes,
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -387,6 +392,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			gameId: doc.gameId ?? undefined,
 			grpcServiceName: doc.grpcServiceName ?? undefined,
 			group: doc.group ?? null,
+			escalationRules,
 			recentChecks: (doc.recentChecks ?? []).map((check: CheckSnapshotDocument) => this.toCheckSnapshot(check)),
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
@@ -410,6 +416,11 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification: unknown) => toStringId(notification));
+		const escalationRules = (doc.escalationRules ?? []).map((rule: any) => ({
+			id: rule.id,
+			channelId: rule.channelId,
+			delayMinutes: rule.delayMinutes,
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -446,6 +457,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			gameId: doc.gameId ?? undefined,
 			grpcServiceName: doc.grpcServiceName ?? undefined,
 			group: doc.group ?? null,
+			escalationRules,
 			recentChecks: (doc.recentChecks ?? []).map((check: CheckSnapshotDocument) => this.toCheckSnapshot(check)),
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -2,6 +2,8 @@ const SERVICE_NAME = "JobQueueHelper";
 import type { Monitor } from "@/types/monitor.js";
 import { supportsGeoCheck } from "@/types/monitor.js";
 import { AppError } from "@/utils/AppError.js";
+import type { MonitorStatusResponse } from "@/types/index.js";
+
 import {
 	ICheckService,
 	INetworkService,
@@ -172,6 +174,16 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 				this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status).catch((error: unknown) => {
 					this.logger.warn({
 						message: `Error handling incident for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+						service: SERVICE_NAME,
+						method: "getMonitorJob",
+						stack: error instanceof Error ? error.stack : undefined,
+					});
+				});
+
+				// Step 8. Handle escalation notifications for long-running downtime
+				this.handleEscalationNotifications(statusChangeResult.monitor, status).catch((error: unknown) => {
+					this.logger.warn({
+						message: `Error handling escalation notifications for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
 						service: SERVICE_NAME,
 						method: "getMonitorJob",
 						stack: error instanceof Error ? error.stack : undefined,
@@ -417,6 +429,64 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 			}
 		};
 	};
+
+	private async handleEscalationNotifications(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): Promise<void> {
+		if (monitor.status !== "down" || !monitor.escalationRules?.length) {
+			return;
+		}
+
+		const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId);
+		if (!activeIncident) {
+			return;
+		}
+
+		const pendingRules = monitor.escalationRules
+			.filter((rule) => {
+				const ruleIdentifier = rule.id || rule.channelId;
+				return !(activeIncident.escalationNotificationsSent ?? []).includes(ruleIdentifier);
+			})
+			.sort((a, b) => a.delayMinutes - b.delayMinutes);
+
+		if (!pendingRules.length) {
+			return;
+		}
+
+		const incidentStart = new Date(activeIncident.startTime).getTime();
+		const now = Date.now();
+
+		for (const rule of pendingRules) {
+			const ruleIdentifier = rule.id || rule.channelId;
+			const sendAt = incidentStart + rule.delayMinutes * 60 * 1000;
+			if (now < sendAt) {
+				continue;
+			}
+
+			const decision: MonitorActionDecision = {
+				shouldCreateIncident: false,
+				shouldResolveIncident: false,
+				shouldSendNotification: true,
+				incidentReason: null,
+				notificationReason: "escalation",
+			};
+
+			const sent = await this.notificationsService.sendNotificationById(rule.channelId, monitor, monitorStatusResponse, decision);
+			if (!sent) {
+				this.logger.warn({
+					message: `Escalation notification failed for monitor ${monitor.id}`,
+					service: SERVICE_NAME,
+					method: "handleEscalationNotifications",
+					details: { channelId: rule.channelId, ruleId: ruleIdentifier },
+				});
+				continue;
+			}
+
+			const escalationNotificationsSent = Array.from(new Set([...(activeIncident.escalationNotificationsSent ?? []), ruleIdentifier]));
+			activeIncident.escalationNotificationsSent = escalationNotificationsSent;
+			await this.incidentsRepository.updateById(activeIncident.id, activeIncident.teamId, {
+				escalationNotificationsSent,
+			});
+		}
+	}
 
 	private evaluateMonitorAction(statusChangeResult: StatusChangeResult): MonitorActionDecision {
 		const { monitor, statusChanged, prevStatus } = statusChangeResult;

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -53,6 +53,11 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	}
 
 	private determineNotificationType(decision: MonitorActionDecision, monitor: Monitor): NotificationType {
+		// Escalation notifications should be explicit
+		if (decision.notificationReason === "escalation" && monitor.status === "down") {
+			return "monitor_escalation";
+		}
+
 		// Down status has highest priority (critical)
 		if (monitor.status === "down") {
 			return "monitor_down";
@@ -97,6 +102,8 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		switch (type) {
 			case "monitor_down":
 				return this.buildMonitorDownContent(monitor, monitorStatusResponse);
+			case "monitor_escalation":
+				return this.buildMonitorEscalationContent(monitor, monitorStatusResponse);
 			case "monitor_up":
 				return this.buildMonitorUpContent(monitor);
 			case "threshold_breach":
@@ -135,6 +142,27 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		const title = `Monitor Recovered: ${monitor.name}`;
 		const summary = `Monitor "${monitor.name}" is back up and operational.`;
 		const details = [`URL: ${monitor.url}`, `Status: Up`, `Type: ${monitor.type}`];
+
+		return {
+			title,
+			summary,
+			details,
+			timestamp: new Date(),
+		};
+	}
+
+	private buildMonitorEscalationContent(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): NotificationContent {
+		const title = `Escalation: Monitor ${monitor.name} still down`;
+		const summary = `Monitor "${monitor.name}" is still down after the configured escalation delay.`;
+		const details = [`URL: ${monitor.url}`, `Status: Down`, `Type: ${monitor.type}`];
+
+		if (monitorStatusResponse.code) {
+			details.push(`Response Code: ${monitorStatusResponse.code}`);
+		}
+
+		if (monitorStatusResponse.message) {
+			details.push(`Error: ${monitorStatusResponse.message}`);
+		}
 
 		return {
 			title,

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -81,6 +81,8 @@ export class EmailProvider implements INotificationProvider {
 		switch (message.type) {
 			case "monitor_down":
 				return `Monitor ${message.monitor.name} is down`;
+			case "monitor_escalation":
+				return `Escalation: Monitor ${message.monitor.name} still down`;
 			case "monitor_up":
 				return `Monitor ${message.monitor.name} is back up`;
 			case "threshold_breach":

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,6 +14,7 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	sendNotificationById: (notificationId: string, monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -139,6 +140,14 @@ export class NotificationsService implements INotificationsService {
 
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	sendNotificationById = async (notificationId: string, monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
+		const notification = await this.notificationsRepository.findById(notificationId, monitor.teamId);
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+		const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, decision, clientHost);
+		return await this.send(notification, monitor, monitorStatusResponse, decision, notificationMessage);
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -15,6 +15,7 @@ export interface Incident {
 	resolutionType: IncidentResolutionType;
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;
+	escalationNotificationsSent?: string[];
 	comment?: string | null;
 	createdAt: string;
 	updatedAt: string;

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,12 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface EscalationRule {
+	id: string;
+	channelId: string;
+	delayMinutes: number;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +43,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationRules: EscalationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/types/notificationMessage.ts
+++ b/server/src/types/notificationMessage.ts
@@ -3,7 +3,7 @@
  * Part of notification system unification effort
  */
 
-export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test";
+export type NotificationType = "monitor_down" | "monitor_escalation" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test";
 
 export type NotificationSeverity = "critical" | "warning" | "info" | "success";
 

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -67,6 +67,15 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalationRules: z
+		.array(
+			z.object({
+				channelId: z.string().min(1, "Notification channel is required"),
+				delayMinutes: z.coerce.number().min(1, "Delay must be at least 1 minute").max(1440, "Delay cannot exceed 1440 minutes"),
+				id: z.string().optional(),
+			})
+		)
+		.optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +98,15 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalationRules: z
+		.array(
+			z.object({
+				channelId: z.string().min(1, "Notification channel is required"),
+				delayMinutes: z.coerce.number().min(1, "Delay must be at least 1 minute").max(1440, "Delay cannot exceed 1440 minutes"),
+				id: z.string().optional(),
+			})
+		)
+		.optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),
@@ -144,6 +162,15 @@ const importedMonitorSchema = z.object({
 	interval: z.number().default(60000),
 	uptimePercentage: z.number().optional(),
 	notifications: z.array(z.string()).default([]),
+	escalationRules: z
+		.array(
+			z.object({
+				channelId: z.string().min(1, "Notification channel is required"),
+				delayMinutes: z.coerce.number().min(1, "Delay must be at least 1 minute").max(1440, "Delay cannot exceed 1440 minutes"),
+				id: z.string().optional(),
+			})
+		)
+		.default([]),
 	secret: z.string().optional(),
 	cpuAlertThreshold: z.number().default(100),
 	cpuAlertCounter: z.number().default(5),


### PR DESCRIPTION
## Describe your changes

Briefly describe the changes you made and their purpose. 

Added feature, esacalation notifications, that notifies users again after a designated time period if the server is still down. 

<img width="1561" height="104" alt="image" src="https://github.com/user-attachments/assets/527d6446-c09c-4372-97fa-48a6951e4735" />

<img width="1559" height="244" alt="image" src="https://github.com/user-attachments/assets/15ae2e79-1710-4965-87ac-60634b18346e" />

## Write your issue number after "Fixes "

Fixes #1 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

