### PR TITLE
Fix escalation channel cleanup when deleting notifications

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalationPolicy: data?.escalationPolicy || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -34,6 +34,7 @@ import { useGet, usePost, usePatch, useDelete } from "@/Hooks/UseApi";
 import { useMonitorForm } from "@/Hooks/useMonitorForm";
 import {
 	type Monitor,
+	type MonitorEscalationStep,
 	type MonitorType,
 	type GamesMap,
 	supportsGeoCheck,
@@ -758,6 +759,114 @@ const CreateMonitorPage = () => {
 											))}
 										</Stack>
 									)}
+								</Stack>
+							);
+						}}
+					/>
+				}
+			/>
+
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalations.title")}
+				subtitle={t("pages.createMonitor.form.escalations.description")}
+				rightContent={
+					<Controller
+						name="escalationPolicy"
+						control={control}
+						render={({ field }) => {
+							const notificationOptions = (notifications ?? []).map((notification) => ({
+								id: notification.id,
+								name: notification.notificationName,
+							}));
+
+							const updateEscalation = (
+								index: number,
+								updates: Partial<MonitorEscalationStep>
+							) => {
+								field.onChange(
+									(field.value ?? []).map((entry, entryIndex) =>
+										entryIndex === index ? { ...entry, ...updates } : entry
+									)
+								);
+							};
+
+							return (
+								<Stack spacing={theme.spacing(LAYOUT.MD)}>
+									{(field.value ?? []).map((entry, index) => (
+										<Stack
+											key={`${entry.notificationId}-${entry.delayMinutes}-${index}`}
+											direction={{ xs: "column", md: "row" }}
+											spacing={theme.spacing(LAYOUT.MD)}
+											alignItems={{ xs: "stretch", md: "flex-end" }}
+										>
+											<Select
+												value={entry.notificationId}
+												fieldLabel={t(
+													"pages.createMonitor.form.escalations.option.channel.label"
+												)}
+												onChange={(event) =>
+													updateEscalation(index, {
+														notificationId: event.target.value as string,
+													})
+												}
+												fullWidth
+											>
+												{notificationOptions.map((option) => (
+													<MenuItem
+														key={option.id}
+														value={option.id}
+													>
+														{option.name}
+													</MenuItem>
+												))}
+											</Select>
+											<TextField
+												type="number"
+												fieldLabel={t(
+													"pages.createMonitor.form.escalations.option.delay.label"
+												)}
+												placeholder={t(
+													"pages.createMonitor.form.escalations.option.delay.placeholder"
+												)}
+												value={entry.delayMinutes}
+												onChange={(event) =>
+													updateEscalation(index, {
+														delayMinutes: Number(event.target.value),
+													})
+												}
+												inputProps={{ min: 1 }}
+												fullWidth
+											/>
+											<IconButton
+												size="small"
+												onClick={() => {
+													field.onChange(
+														(field.value ?? []).filter(
+															(_, entryIndex) => entryIndex !== index
+														)
+													);
+												}}
+												aria-label="Remove escalation"
+											>
+												<Trash2 size={16} />
+											</IconButton>
+										</Stack>
+									))}
+									<Button
+										variant="outlined"
+										onClick={() => {
+											field.onChange([
+												...(field.value ?? []),
+												{
+													notificationId: notificationOptions[0]?.id ?? "",
+													delayMinutes: 5,
+												},
+											]);
+										}}
+										disabled={notificationOptions.length === 0}
+									>
+										{t("pages.createMonitor.form.escalations.addStep")}
+									</Button>
 								</Stack>
 							);
 						}}

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface MonitorEscalationStep {
+	notificationId: string;
+	delayMinutes: number;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +65,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationPolicy: MonitorEscalationStep[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -4,6 +4,14 @@ import { GeoContinents } from "@/Types/GeoCheck";
 // URL schema with custom error message
 const urlSchema = z.url({ message: "Please enter a valid URL" });
 
+const escalationStepSchema = z.object({
+	notificationId: z.string().min(1, "Notification channel is required"),
+	delayMinutes: z
+		.number({ message: "Delay is required" })
+		.int("Delay must be a whole number of minutes")
+		.min(1, "Delay must be at least 1 minute"),
+});
+
 // Common base schema for all monitor types
 const baseSchema = z.object({
 	name: z
@@ -13,6 +21,7 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalationPolicy: z.array(escalationStepSchema),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -543,6 +543,20 @@
 					"description": "Select the notification channels you want to use",
 					"title": "Notifications"
 				},
+				"escalations": {
+					"title": "Escalated notifications",
+					"description": "Add delayed notification steps that should fire only if the incident is still active after the selected number of minutes.",
+					"addStep": "Add escalation step",
+					"option": {
+						"channel": {
+							"label": "Notification channel"
+						},
+						"delay": {
+							"label": "Delay in minutes",
+							"placeholder": "5"
+						}
+					}
+				},
 				"type": {
 					"description": "Select the type of check to perform",
 					"optionDockerDescription": "Use Docker to monitor if a container is running.",

--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -234,6 +234,7 @@ export const initializeServices = async ({
 	const notificationsService = new NotificationsService(
 		notificationsRepository,
 		monitorsRepository,
+		incidentsRepository,
 		webhookProvider,
 		emailProvider,
 		slackProvider,

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -54,6 +54,10 @@ const IncidentSchema = new Schema<IncidentDocument>(
 			default: null,
 			index: true,
 		},
+		sentEscalations: {
+			type: [String],
+			default: [],
+		},
 		resolutionType: {
 			type: String,
 			enum: IncidentResolutionTypes,

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -1,5 +1,5 @@
 import { Schema, model, Types } from "mongoose";
-import type { Monitor, MonitorMatchMethod, CheckSnapshot } from "@/types/monitor.js";
+import type { Monitor, MonitorMatchMethod, CheckSnapshot, MonitorEscalationStep } from "@/types/monitor.js";
 import { MonitorTypes, MonitorStatuses } from "@/types/monitor.js";
 import type {
 	CheckAudits,
@@ -23,6 +23,7 @@ type MonitorDocumentBase = Omit<
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
+	escalationPolicy: MonitorEscalationStep[];
 	selectedDisks: string[];
 	matchMethod?: MonitorMatchMethod;
 };
@@ -198,6 +199,21 @@ const checkSnapshotSchema = new Schema<CheckSnapshotDocument>(
 	{ _id: false }
 );
 
+const escalationStepSchema = new Schema<MonitorEscalationStep>(
+	{
+		notificationId: {
+			type: String,
+			required: true,
+		},
+		delayMinutes: {
+			type: Number,
+			required: true,
+			min: 1,
+		},
+	},
+	{ _id: false }
+);
+
 const MonitorSchema = new Schema<MonitorDocument>(
 	{
 		userId: {
@@ -284,6 +300,10 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalationPolicy: {
+			type: [escalationStepSchema],
+			default: [],
+		},
 		secret: {
 			type: String,
 		},

--- a/server/src/repositories/incidents/MongoIncidentRepository.ts
+++ b/server/src/repositories/incidents/MongoIncidentRepository.ts
@@ -56,6 +56,7 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			status: doc.status,
 			message: doc.message ?? null,
 			statusCode: doc.statusCode ?? null,
+			sentEscalations: doc.sentEscalations ?? [],
 			resolutionType: doc.resolutionType ?? null,
 			resolvedBy: doc.resolvedBy ? this.toStringId(doc.resolvedBy) : null,
 			resolvedByEmail: doc.resolvedByEmail ?? null,

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -374,6 +374,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalationPolicy: (doc.escalationPolicy ?? []).map((entry) => ({
+				notificationId: entry.notificationId,
+				delayMinutes: entry.delayMinutes,
+			})),
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -433,6 +437,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalationPolicy: (doc.escalationPolicy ?? []).map((entry) => ({
+				notificationId: entry.notificationId,
+				delayMinutes: entry.delayMinutes,
+			})),
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -293,7 +293,17 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 	};
 
 	removeNotificationFromMonitors = async (notificationId: string): Promise<void> => {
-		await MonitorModel.updateMany({ notifications: notificationId }, { $pull: { notifications: notificationId } });
+		await MonitorModel.updateMany(
+			{
+				$or: [{ notifications: notificationId }, { "escalationPolicy.notificationId": notificationId }],
+			},
+			{
+				$pull: {
+					notifications: notificationId,
+					escalationPolicy: { notificationId },
+				},
+			}
+		);
 	};
 
 	updateNotifications = async (

--- a/server/src/service/business/incidentService.ts
+++ b/server/src/service/business/incidentService.ts
@@ -90,6 +90,7 @@ export class IncidentService implements IIncidentService {
 					status: true,
 					statusCode,
 					message,
+					sentEscalations: [],
 				};
 				return await this.incidentsRepository.create(incident);
 			}

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -157,16 +157,14 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 				const decision = this.evaluateMonitorAction(statusChangeResult);
 
 				// Step 6. Handle notifications (best effort, continue even in event of failure, don't wait)
-				if (decision.shouldSendNotification) {
-					this.notificationsService.handleNotifications(statusChangeResult.monitor, status, decision).catch((error: unknown) => {
-						this.logger.error({
-							message: `Error sending notifications for job ${statusChangeResult.monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
-							service: SERVICE_NAME,
-							method: "getMonitorJob",
-							stack: error instanceof Error ? error.stack : undefined,
-						});
+				this.notificationsService.handleNotifications(statusChangeResult.monitor, status, decision).catch((error: unknown) => {
+					this.logger.error({
+						message: `Error sending notifications for job ${statusChangeResult.monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+						service: SERVICE_NAME,
+						method: "getMonitorJob",
+						stack: error instanceof Error ? error.stack : undefined,
 					});
-				}
+				});
 
 				// Step 7. Handle incidents (best effort, don't wait)
 				this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status).catch((error: unknown) => {

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -1,4 +1,5 @@
 import type { HardwareStatusPayload, Monitor, MonitorStatusResponse } from "@/types/index.js";
+import type { Incident } from "@/types/incident.js";
 import type { MonitorActionDecision } from "@/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.js";
 import type {
 	NotificationMessage,
@@ -13,7 +14,9 @@ export interface INotificationMessageBuilder {
 		monitor: Monitor,
 		monitorStatusResponse: MonitorStatusResponse,
 		decision: MonitorActionDecision,
-		clientHost: string
+		clientHost: string,
+		incident?: Incident | null,
+		escalationDelayMinutes?: number
 	): NotificationMessage;
 	extractThresholdBreaches(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): ThresholdBreach[];
 }
@@ -27,11 +30,13 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		monitor: Monitor,
 		monitorStatusResponse: MonitorStatusResponse,
 		decision: MonitorActionDecision,
-		clientHost: string
+		clientHost: string,
+		incident?: Incident | null,
+		escalationDelayMinutes?: number
 	): NotificationMessage {
 		const type = this.determineNotificationType(decision, monitor);
 		const severity = this.determineSeverity(type);
-		const content = this.buildContent(type, monitor, monitorStatusResponse);
+		const content = this.buildContent(type, monitor, monitorStatusResponse, clientHost, incident, escalationDelayMinutes);
 
 		return {
 			type,
@@ -93,14 +98,27 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		}
 	}
 
-	private buildContent(type: NotificationType, monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): NotificationContent {
+	private buildContent(
+		type: NotificationType,
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		clientHost: string,
+		incident?: Incident | null,
+		escalationDelayMinutes?: number
+	): NotificationContent {
 		switch (type) {
 			case "monitor_down":
-				return this.buildMonitorDownContent(monitor, monitorStatusResponse);
+				return this.buildMonitorDownContent(monitor, monitorStatusResponse, clientHost, incident, escalationDelayMinutes);
 			case "monitor_up":
 				return this.buildMonitorUpContent(monitor);
 			case "threshold_breach":
-				return this.buildThresholdBreachContent(monitor, monitorStatusResponse as MonitorStatusResponse<HardwareStatusPayload>);
+				return this.buildThresholdBreachContent(
+					monitor,
+					monitorStatusResponse as MonitorStatusResponse<HardwareStatusPayload>,
+					clientHost,
+					incident,
+					escalationDelayMinutes
+				);
 			case "threshold_resolved":
 				return this.buildThresholdResolvedContent(monitor);
 			default:
@@ -108,7 +126,13 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		}
 	}
 
-	private buildMonitorDownContent(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): NotificationContent {
+	private buildMonitorDownContent(
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		clientHost: string,
+		incident?: Incident | null,
+		escalationDelayMinutes?: number
+	): NotificationContent {
 		const title = `Monitor Down: ${monitor.name}`;
 		const summary = `Monitor "${monitor.name}" is currently down and unreachable.`;
 		const details = [`URL: ${monitor.url}`, `Status: Down`, `Type: ${monitor.type}`];
@@ -123,10 +147,14 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 			details.push(`Error: ${monitorStatusResponse.message}`);
 		}
 
+		const incidentInfo = this.buildIncidentInfo(clientHost, incident);
+		this.addEscalationDetails(details, incidentInfo?.duration, escalationDelayMinutes);
+
 		return {
 			title,
 			summary,
 			details,
+			incident: incidentInfo,
 			timestamp: new Date(),
 		};
 	}
@@ -144,20 +172,72 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		};
 	}
 
-	private buildThresholdBreachContent(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse<HardwareStatusPayload>): NotificationContent {
+	private buildThresholdBreachContent(
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse<HardwareStatusPayload>,
+		clientHost: string,
+		incident?: Incident | null,
+		escalationDelayMinutes?: number
+	): NotificationContent {
 		const title = `Threshold Exceeded: ${monitor.name}`;
 		const summary = `Monitor "${monitor.name}" has exceeded one or more thresholds.`;
 		const details = [`URL: ${monitor.url}`, `Status: Threshold exceeded`, `Type: ${monitor.type}`];
 
 		const thresholds = this.extractThresholdBreaches(monitor, monitorStatusResponse);
+		const incidentInfo = this.buildIncidentInfo(clientHost, incident);
+		this.addEscalationDetails(details, incidentInfo?.duration, escalationDelayMinutes);
 
 		return {
 			title,
 			summary,
 			details,
 			thresholds,
+			incident: incidentInfo,
 			timestamp: new Date(),
 		};
+	}
+
+	private buildIncidentInfo(clientHost: string, incident?: Incident | null): NotificationContent["incident"] | undefined {
+		if (!incident) {
+			return undefined;
+		}
+
+		return {
+			id: incident.id,
+			url: `${clientHost}/incidents/${incident.id}`,
+			createdAt: new Date(incident.startTime),
+			resolvedAt: incident.endTime ? new Date(incident.endTime) : undefined,
+			duration: this.formatDuration(Date.now() - new Date(incident.startTime).getTime()),
+		};
+	}
+
+	private addEscalationDetails(details: string[], incidentDuration?: string, escalationDelayMinutes?: number): void {
+		if (incidentDuration) {
+			details.push(`Incident duration: ${incidentDuration}`);
+		}
+		if (escalationDelayMinutes) {
+			details.push(`Escalation delay reached: ${escalationDelayMinutes} minute${escalationDelayMinutes === 1 ? "" : "s"}`);
+		}
+	}
+
+	private formatDuration(durationMs: number): string {
+		if (durationMs <= 0) {
+			return "0 minutes";
+		}
+
+		const totalMinutes = Math.floor(durationMs / 60000);
+		const hours = Math.floor(totalMinutes / 60);
+		const minutes = totalMinutes % 60;
+
+		if (hours === 0) {
+			return `${totalMinutes} minute${totalMinutes === 1 ? "" : "s"}`;
+		}
+
+		if (minutes === 0) {
+			return `${hours} hour${hours === 1 ? "" : "s"}`;
+		}
+
+		return `${hours} hour${hours === 1 ? "" : "s"} ${minutes} minute${minutes === 1 ? "" : "s"}`;
 	}
 
 	private buildThresholdResolvedContent(monitor: Monitor): NotificationContent {

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -1,6 +1,6 @@
-import type { Monitor, MonitorStatusResponse, Notification } from "@/types/index.js";
+import type { Incident, Monitor, MonitorEscalationStep, MonitorStatusResponse, Notification } from "@/types/index.js";
 import type { NotificationMessage } from "@/types/notificationMessage.js";
-import { IMonitorsRepository, INotificationsRepository } from "@/repositories/index.js";
+import { IIncidentsRepository, IMonitorsRepository, INotificationsRepository } from "@/repositories/index.js";
 import { INotificationProvider } from "./notificationProviders/INotificationProvider.js";
 import type { MonitorActionDecision } from "@/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.js";
 import type { ISettingsService } from "@/service/system/settingsService.js";
@@ -26,6 +26,7 @@ export class NotificationsService implements INotificationsService {
 
 	private notificationsRepository: INotificationsRepository;
 	private monitorsRepository: IMonitorsRepository;
+	private incidentsRepository: IIncidentsRepository;
 	private webhookProvider: INotificationProvider;
 	private emailProvider: INotificationProvider;
 	private slackProvider: INotificationProvider;
@@ -40,6 +41,7 @@ export class NotificationsService implements INotificationsService {
 	constructor(
 		notificationsRepository: INotificationsRepository,
 		monitorsRepository: IMonitorsRepository,
+		incidentsRepository: IIncidentsRepository,
 		webhookProvider: INotificationProvider,
 		emailProvider: INotificationProvider,
 		slackProvider: INotificationProvider,
@@ -53,6 +55,7 @@ export class NotificationsService implements INotificationsService {
 	) {
 		this.notificationsRepository = notificationsRepository;
 		this.monitorsRepository = monitorsRepository;
+		this.incidentsRepository = incidentsRepository;
 		this.webhookProvider = webhookProvider;
 		this.emailProvider = emailProvider;
 		this.slackProvider = slackProvider;
@@ -132,13 +135,97 @@ export class NotificationsService implements INotificationsService {
 		return succeeded === notifications.length;
 	};
 
-	handleNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
-		if (!decision.shouldSendNotification) {
+	private getEscalationKey(step: MonitorEscalationStep): string {
+		return `${step.notificationId}:${step.delayMinutes}`;
+	}
+
+	private getDueEscalations(monitor: Monitor, incident: Incident): MonitorEscalationStep[] {
+		const escalationPolicy = monitor.escalationPolicy ?? [];
+		if (escalationPolicy.length === 0) {
+			return [];
+		}
+
+		const incidentDurationMs = Date.now() - new Date(incident.startTime).getTime();
+
+		return escalationPolicy.filter((step) => {
+			const escalationKey = this.getEscalationKey(step);
+			return incidentDurationMs >= step.delayMinutes * 60000 && !(incident.sentEscalations ?? []).includes(escalationKey);
+		});
+	}
+
+	private sendEscalationNotifications = async (
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		decision: MonitorActionDecision,
+		incident: Incident
+	): Promise<boolean> => {
+		const dueEscalations = this.getDueEscalations(monitor, incident);
+		if (dueEscalations.length === 0) {
 			return false;
 		}
 
-		// Send notifications based on decision
-		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+
+		const successfulEscalations: string[] = [];
+		let allSucceeded = true;
+
+		for (const escalation of dueEscalations) {
+			const notification = await this.notificationsRepository.findById(escalation.notificationId, monitor.teamId).catch(() => null);
+			if (!notification) {
+				allSucceeded = false;
+				continue;
+			}
+
+			const notificationMessage = this.notificationMessageBuilder.buildMessage(
+				monitor,
+				monitorStatusResponse,
+				decision,
+				clientHost,
+				incident,
+				escalation.delayMinutes
+			);
+			const sent = await this.send(notification, monitor, monitorStatusResponse, decision, notificationMessage);
+			if (sent) {
+				successfulEscalations.push(this.getEscalationKey(escalation));
+			} else {
+				allSucceeded = false;
+			}
+		}
+
+		if (successfulEscalations.length > 0) {
+			await this.incidentsRepository.updateById(incident.id, incident.teamId, {
+				sentEscalations: [...new Set([...(incident.sentEscalations ?? []), ...successfulEscalations])],
+			});
+		}
+
+		return allSucceeded;
+	};
+
+	handleNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
+		let sentAny = false;
+
+		if (decision.shouldSendNotification) {
+			sentAny = await this.sendNotifications(monitor, monitorStatusResponse, decision);
+		}
+
+		if (monitor.status !== "down" && monitor.status !== "breached") {
+			return sentAny;
+		}
+
+		const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId);
+		if (!activeIncident) {
+			return sentAny;
+		}
+
+		const escalationDecision: MonitorActionDecision = {
+			...decision,
+			shouldSendNotification: true,
+			notificationReason: monitor.status === "breached" ? "threshold_breach" : "status_change",
+		};
+
+		const escalationSent = await this.sendEscalationNotifications(monitor, monitorStatusResponse, escalationDecision, activeIncident);
+		return sentAny || escalationSent;
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -12,6 +12,7 @@ export interface Incident {
 	status: boolean;
 	message?: string | null;
 	statusCode?: number | null;
+	sentEscalations: string[];
 	resolutionType: IncidentResolutionType;
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface MonitorEscalationStep {
+	notificationId: string;
+	delayMinutes: number;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +42,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationPolicy: MonitorEscalationStep[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -3,6 +3,11 @@ import { booleanCoercion } from "./shared.js";
 import { GeoContinents } from "@/types/geoCheck.js";
 import { MonitorMatchMethods, MonitorTypes } from "@/types/monitor.js";
 
+const escalationStepValidation = z.object({
+	notificationId: z.string().min(1, "Notification ID is required"),
+	delayMinutes: z.number().int().min(1, "Delay must be at least 1 minute"),
+});
+
 export const getMonitorByIdParamValidation = z.object({
 	monitorId: z.string().min(1, "Monitor ID is required"),
 });
@@ -67,6 +72,7 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalationPolicy: z.array(escalationStepValidation).optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -102,6 +108,7 @@ export const editMonitorBodyValidation = z.object({
 	tempAlertThreshold: z.number().optional(),
 	gameId: z.union([z.string(), z.literal("")]).optional(),
 	grpcServiceName: z.union([z.string(), z.literal("")]).optional(),
+	escalationPolicy: z.array(escalationStepValidation).optional(),
 	selectedDisks: z.array(z.string()).optional(),
 	group: z.union([z.string().max(50).trim(), z.null(), z.literal("")]).optional(),
 	geoCheckEnabled: z.boolean().optional(),
@@ -144,6 +151,7 @@ const importedMonitorSchema = z.object({
 	interval: z.number().default(60000),
 	uptimePercentage: z.number().optional(),
 	notifications: z.array(z.string()).default([]),
+	escalationPolicy: z.array(escalationStepValidation).default([]),
 	secret: z.string().optional(),
 	cpuAlertThreshold: z.number().default(100),
 	cpuAlertCounter: z.number().default(5),

--- a/server/test/notificationsService.test.ts
+++ b/server/test/notificationsService.test.ts
@@ -124,4 +124,34 @@ describe("NotificationsService escalations", () => {
 			expect.objectContaining({ sentEscalations: ["notification-1:5"] })
 		);
 	});
+
+	it("removes deleted notification channels from monitor references", async () => {
+		const monitorsRepository = {
+			removeNotificationFromMonitors: jest.fn().mockResolvedValue(undefined),
+		};
+		const notificationsRepository = {
+			deleteById: jest.fn().mockResolvedValue(createNotification()),
+		};
+
+		const service = new NotificationsService(
+			notificationsRepository as never,
+			monitorsRepository as never,
+			{} as never,
+			{ sendMessage: jest.fn(), sendTestAlert: jest.fn() } as never,
+			{ sendMessage: jest.fn(), sendTestAlert: jest.fn() } as never,
+			{ sendMessage: jest.fn(), sendTestAlert: jest.fn() } as never,
+			{ sendMessage: jest.fn(), sendTestAlert: jest.fn() } as never,
+			{ sendMessage: jest.fn(), sendTestAlert: jest.fn() } as never,
+			{ sendMessage: jest.fn(), sendTestAlert: jest.fn() } as never,
+			{ sendMessage: jest.fn(), sendTestAlert: jest.fn() } as never,
+			{ getSettings: jest.fn().mockReturnValue({ clientHost: "http://localhost:3000" }) } as never,
+			{ warn: jest.fn(), info: jest.fn(), error: jest.fn(), debug: jest.fn() } as never,
+			new NotificationMessageBuilder()
+		);
+
+		await service.deleteById("notification-1", "team-1");
+
+		expect(notificationsRepository.deleteById).toHaveBeenCalledWith("notification-1", "team-1");
+		expect(monitorsRepository.removeNotificationFromMonitors).toHaveBeenCalledWith("notification-1");
+	});
 });

--- a/server/test/notificationsService.test.ts
+++ b/server/test/notificationsService.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { NotificationsService } from "../src/service/infrastructure/notificationsService.ts";
+import { NotificationMessageBuilder } from "../src/service/infrastructure/notificationMessageBuilder.ts";
+import type { Incident, Monitor, Notification } from "../src/types/index.ts";
+
+const createNotification = (): Notification => ({
+	id: "notification-1",
+	userId: "user-1",
+	teamId: "team-1",
+	type: "email",
+	notificationName: "Ops Email",
+	address: "ops@example.com",
+	createdAt: new Date().toISOString(),
+	updatedAt: new Date().toISOString(),
+});
+
+const createMonitor = (): Monitor => ({
+	id: "monitor-1",
+	userId: "user-1",
+	teamId: "team-1",
+	name: "API",
+	status: "down",
+	statusWindow: [],
+	statusWindowSize: 5,
+	statusWindowThreshold: 60,
+	type: "http",
+	ignoreTlsErrors: false,
+	useAdvancedMatching: false,
+	url: "https://example.com",
+	isActive: true,
+	interval: 60000,
+	notifications: [],
+	escalationPolicy: [{ notificationId: "notification-1", delayMinutes: 5 }],
+	cpuAlertThreshold: 100,
+	cpuAlertCounter: 5,
+	memoryAlertThreshold: 100,
+	memoryAlertCounter: 5,
+	diskAlertThreshold: 100,
+	diskAlertCounter: 5,
+	tempAlertThreshold: 100,
+	tempAlertCounter: 5,
+	selectedDisks: [],
+	group: null,
+	recentChecks: [],
+	createdAt: new Date().toISOString(),
+	updatedAt: new Date().toISOString(),
+});
+
+const createIncident = (): Incident => ({
+	id: "incident-1",
+	monitorId: "monitor-1",
+	teamId: "team-1",
+	startTime: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+	endTime: null,
+	status: true,
+	message: null,
+	statusCode: 500,
+	sentEscalations: [],
+	resolutionType: null,
+	resolvedBy: null,
+	resolvedByEmail: null,
+	comment: null,
+	createdAt: new Date().toISOString(),
+	updatedAt: new Date().toISOString(),
+});
+
+describe("NotificationsService escalations", () => {
+	it("sends due escalations once an incident duration crosses the configured delay", async () => {
+		const notification = createNotification();
+		const incident = createIncident();
+		const emailProvider = {
+			sendMessage: jest.fn().mockResolvedValue(true),
+			sendTestAlert: jest.fn(),
+		};
+		const incidentsRepository = {
+			findActiveByMonitorId: jest.fn().mockResolvedValue(incident),
+			updateById: jest.fn().mockResolvedValue({
+				...incident,
+				sentEscalations: ["notification-1:5"],
+			}),
+		};
+		const notificationsRepository = {
+			findNotificationsByIds: jest.fn().mockResolvedValue([]),
+			findById: jest.fn().mockResolvedValue(notification),
+			create: jest.fn(),
+			findByTeamId: jest.fn(),
+			updateById: jest.fn(),
+			deleteById: jest.fn(),
+		};
+
+		const service = new NotificationsService(
+			notificationsRepository as never,
+			{ removeNotificationFromMonitors: jest.fn() } as never,
+			incidentsRepository as never,
+			{ sendMessage: jest.fn(), sendTestAlert: jest.fn() } as never,
+			emailProvider as never,
+			{ sendMessage: jest.fn(), sendTestAlert: jest.fn() } as never,
+			{ sendMessage: jest.fn(), sendTestAlert: jest.fn() } as never,
+			{ sendMessage: jest.fn(), sendTestAlert: jest.fn() } as never,
+			{ sendMessage: jest.fn(), sendTestAlert: jest.fn() } as never,
+			{ sendMessage: jest.fn(), sendTestAlert: jest.fn() } as never,
+			{ getSettings: jest.fn().mockReturnValue({ clientHost: "http://localhost:3000" }) } as never,
+			{ warn: jest.fn(), info: jest.fn(), error: jest.fn(), debug: jest.fn() } as never,
+			new NotificationMessageBuilder()
+		);
+
+		const result = await service.handleNotifications(
+			createMonitor(),
+			{ code: 500, message: "Connection refused", status: false },
+			{
+				shouldCreateIncident: false,
+				shouldResolveIncident: false,
+				shouldSendNotification: false,
+				incidentReason: null,
+				notificationReason: null,
+			}
+		);
+
+		expect(result).toBe(true);
+		expect(emailProvider.sendMessage).toHaveBeenCalledTimes(1);
+		expect(incidentsRepository.updateById).toHaveBeenCalledWith(
+			"incident-1",
+			"team-1",
+			expect.objectContaining({ sentEscalations: ["notification-1:5"] })
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- remove deleted notification channels from both direct monitor notifications and escalation policies
- keep monitor escalation config from persisting stale notification ids after a channel is deleted
- add a regression test covering notification deletion cleanup alongside the escalation send test

## Testing
- node .\\node_modules\\typescript\\bin\\tsc --noEmit
- node .\\node_modules\\c8\\bin\\c8.js node --experimental-vm-modules .\\node_modules\\jest\\bin\\jest.js --runInBand notificationsService.test.ts