### PR TITLE
Add escalated notifications (frontend + backend + email trigger)

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,8 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalationAfterMinutes: data?.escalationAfterMinutes ?? null,
+	escalationNotifications: data?.escalationNotifications || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -765,6 +765,97 @@ const CreateMonitorPage = () => {
 				}
 			/>
 
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalation.title")}
+				subtitle={t("pages.createMonitor.form.escalation.description")}
+				rightContent={
+					<Stack spacing={theme.spacing(LAYOUT.MD)}>
+						<Controller
+							name="escalationAfterMinutes"
+							control={control}
+							render={({ field, fieldState }) => (
+								<TextField
+									{...field}
+									type="number"
+									label={t("pages.createMonitor.form.escalation.option.afterMinutes.label")}
+									error={!!fieldState.error}
+									helperText={fieldState.error?.message}
+									inputProps={{ min: 1, max: 1440 }}
+									value={field.value ?? ""}
+									onChange={(e) => {
+										const value = e.target.value;
+										const numValue = value === "" ? null : parseInt(value, 10);
+										field.onChange(numValue);
+									}}
+								/>
+							)}
+						/>
+						<Controller
+							name="escalationNotifications"
+							control={control}
+							render={({ field }) => {
+								// Map notifications to have 'name' property for Autocomplete
+								const notificationOptions = (notifications ?? []).map((n) => ({
+									...n,
+									name: n.notificationName,
+								}));
+								const selectedNotifications = notificationOptions.filter((n) =>
+									(field.value ?? []).includes(n.id)
+								);
+								return (
+									<Stack spacing={theme.spacing(LAYOUT.MD)}>
+										<Autocomplete
+											multiple
+											options={notificationOptions}
+											value={selectedNotifications}
+											getOptionLabel={(option) => option.name}
+											onChange={(_: unknown, newValue: typeof notificationOptions) => {
+												field.onChange(newValue.map((n) => n.id));
+											}}
+											isOptionEqualToValue={(option, value) => option.id === value.id}
+											placeholder={t("pages.createMonitor.form.escalation.option.channels.placeholder")}
+										/>
+										{selectedNotifications.length > 0 && (
+											<Stack
+												flex={1}
+												width="100%"
+											>
+												{selectedNotifications.map((notification, index) => (
+													<Stack
+														direction="row"
+														alignItems="center"
+														key={notification.id}
+														width="100%"
+													>
+														<Typography flexGrow={1}>
+															{notification.notificationName}
+														</Typography>
+														<IconButton
+															size="small"
+															onClick={() => {
+																field.onChange(
+																	(field.value ?? []).filter(
+																		(id: string) => id !== notification.id
+																	)
+																);
+															}}
+															aria-label="Remove notification"
+														>
+															<Trash2 size={16} />
+														</IconButton>
+														{index < selectedNotifications.length - 1 && <Divider />}
+													</Stack>
+												))}
+											</Stack>
+										)}
+									</Stack>
+								);
+							}}
+						/>
+					</Stack>
+				}
+			/>
+
 			{(watchedType === "http" ||
 				watchedType === "grpc" ||
 				watchedType === "websocket") && (

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -60,6 +60,8 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationAfterMinutes?: number | null;
+	escalationNotifications: string[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -13,6 +13,13 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalationAfterMinutes: z
+		.number()
+		.min(1, "Escalation delay must be at least 1 minute")
+		.max(1440, "Escalation delay must be at most 1440 minutes")
+		.nullable()
+		.optional(),
+	escalationNotifications: z.array(z.string()).optional(),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -543,6 +543,18 @@
 					"description": "Select the notification channels you want to use",
 					"title": "Notifications"
 				},
+				"escalation": {
+					"description": "Configure escalation rules to notify additional channels if the monitor stays down",
+					"title": "Escalation Rules",
+					"option": {
+						"afterMinutes": {
+							"label": "Escalate after (minutes)"
+						},
+						"channels": {
+							"placeholder": "Select escalation notification channels"
+						}
+					}
+				},
 				"type": {
 					"description": "Select the type of check to perform",
 					"optionDockerDescription": "Use Docker to monitor if a container is running.",

--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -267,6 +267,9 @@ export const initializeServices = async ({
 
 	const superSimpleQueue = await SuperSimpleQueue.create(logger, superSimpleQueueHelper, monitorsRepository);
 
+	// Set queue on helper to enable escalation scheduling
+	superSimpleQueueHelper.setQueue(superSimpleQueue);
+
 	// Business services
 	const userService = new UserService({
 		crypto,

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -72,6 +72,14 @@ const IncidentSchema = new Schema<IncidentDocument>(
 			type: String,
 			default: null,
 		},
+		escalationTriggeredAt: {
+			type: Date,
+			default: null,
+		},
+		escalationSentAt: {
+			type: Date,
+			default: null,
+		},
 	},
 	{ timestamps: true }
 );

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -284,6 +284,15 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalationAfterMinutes: {
+			type: Number,
+			default: null,
+		},
+		escalationNotifications: {
+			type: [Schema.Types.ObjectId],
+			ref: "Notification",
+			default: [],
+		},
 		secret: {
 			type: String,
 		},

--- a/server/src/repositories/incidents/MongoIncidentRepository.ts
+++ b/server/src/repositories/incidents/MongoIncidentRepository.ts
@@ -60,6 +60,8 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			resolvedBy: doc.resolvedBy ? this.toStringId(doc.resolvedBy) : null,
 			resolvedByEmail: doc.resolvedByEmail ?? null,
 			comment: doc.comment ?? null,
+			escalationTriggeredAt: doc.escalationTriggeredAt ? this.toDateString(doc.escalationTriggeredAt) : null,
+			escalationSentAt: doc.escalationSentAt ? this.toDateString(doc.escalationSentAt) : null,
 			createdAt: this.toDateString(doc.createdAt),
 			updatedAt: this.toDateString(doc.updatedAt),
 		};

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -351,6 +351,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification) => toStringId(notification));
+		const escalationNotificationIds = (doc.escalationNotifications ?? []).map((notification) => toStringId(notification));
 
 		return {
 			id: toStringId(doc._id),
@@ -374,6 +375,8 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalationAfterMinutes: doc.escalationAfterMinutes ?? undefined,
+			escalationNotifications: escalationNotificationIds,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueue.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueue.ts
@@ -47,6 +47,7 @@ export interface ISuperSimpleQueue {
 	pauseJob(monitor: Monitor): Promise<void>;
 	resumeJob(monitor: Monitor): Promise<void>;
 	updateJob(monitor: Monitor): Promise<void>;
+	scheduleEscalationJob(incidentId: string, monitorId: string, teamId: string, delayMs: number): Promise<void>;
 	shutdown(): Promise<void>;
 	getMetrics(): Promise<QueueMetrics>;
 	getJobs(): Promise<QueueJobSummary[]>;
@@ -93,6 +94,7 @@ export class SuperSimpleQueue implements ISuperSimpleQueue {
 			this.scheduler.addTemplate("geo-check-job", this.helper.getHeartbeatGeoJob());
 			this.scheduler.addTemplate("cleanup-orphaned", this.helper.getCleanupOrphanedJob());
 			this.scheduler.addTemplate("cleanup-retention-job", this.helper.getCleanupRetentionJob());
+			this.scheduler.addTemplate("escalation-job", this.helper.getEscalationJob());
 			const monitors = await this.monitorsRepository.findAll();
 			if (!monitors) {
 				return true;
@@ -202,6 +204,30 @@ export class SuperSimpleQueue implements ISuperSimpleQueue {
 			// Remove geo job if disabled or monitor type changed
 			this.scheduler.removeJob(geoJobId);
 		}
+	};
+
+	scheduleEscalationJob = async (incidentId: string, monitorId: string, teamId: string, delayMs: number) => {
+		const jobId = `escalation-${incidentId}`;
+		const runAt = new Date(Date.now() + delayMs);
+
+		this.scheduler.addJob({
+			id: jobId,
+			template: "escalation-job",
+			repeat: 0, // One-time job
+			active: true,
+			runAt: runAt.getTime().toString(),
+			data: {
+				incidentId,
+				monitorId,
+				teamId,
+			},
+		});
+
+		this.logger.debug({
+			message: `Scheduled escalation job ${jobId} to run at ${runAt.toISOString()}`,
+			service: SERVICE_NAME,
+			method: "scheduleEscalationJob",
+		});
 	};
 
 	shutdown = async () => {

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -30,6 +30,7 @@ export interface ISuperSimpleQueueHelper {
 	getHeartbeatGeoJob(): (monitor: Monitor) => Promise<void>;
 	getCleanupOrphanedJob(): () => Promise<void>;
 	getCleanupRetentionJob(): () => Promise<void>;
+	getEscalationJob(): (data: { incidentId: string; monitorId: string; teamId: string }) => Promise<void>;
 	isInMaintenanceWindow(monitorId: string, teamId: string): Promise<boolean>;
 }
 
@@ -66,6 +67,7 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 	private incidentsRepository: IIncidentsRepository;
 	private geoChecksService: IGeoChecksService;
 	private geoChecksRepository: IGeoChecksRepository;
+	private queue: any; // Will be set after queue is created to avoid circular dependency
 
 	constructor(
 		logger: ILogger,
@@ -106,6 +108,10 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 	get serviceName() {
 		return SuperSimpleQueueHelper.SERVICE_NAME;
 	}
+
+	setQueue = (queue: any) => {
+		this.queue = queue;
+	};
 
 	getHeartbeatJob = () => {
 		return async (monitor: Monitor) => {
@@ -169,14 +175,40 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 				}
 
 				// Step 7. Handle incidents (best effort, don't wait)
-				this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status).catch((error: unknown) => {
-					this.logger.warn({
-						message: `Error handling incident for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
-						service: SERVICE_NAME,
-						method: "getMonitorJob",
-						stack: error instanceof Error ? error.stack : undefined,
-					});
-				});
+				const createdIncident = await this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status);
+				
+				// Step 8. Schedule escalation job if incident was created with escalation configured
+				if (createdIncident && this.queue && statusChangeResult.monitor.escalationAfterMinutes && statusChangeResult.monitor.escalationNotifications && statusChangeResult.monitor.escalationNotifications.length > 0) {
+					const delayMs = statusChangeResult.monitor.escalationAfterMinutes * 60 * 1000; // Convert minutes to milliseconds
+					const escalationTriggeredAt = new Date().toISOString();
+
+					// Update incident to mark when escalation was triggered
+					createdIncident.escalationTriggeredAt = escalationTriggeredAt;
+					await this.incidentsRepository.updateById(createdIncident.id, createdIncident.teamId, createdIncident);
+
+					// Schedule the escalation job
+					try {
+						await this.queue.scheduleEscalationJob(
+							createdIncident.id,
+							statusChangeResult.monitor.id,
+							statusChangeResult.monitor.teamId,
+							delayMs
+						);
+						this.logger.debug({
+							message: `Scheduled escalation job for incident ${createdIncident.id} in ${statusChangeResult.monitor.escalationAfterMinutes} minutes`,
+							service: SERVICE_NAME,
+							method: "getMonitorJob",
+						});
+					} catch (error: unknown) {
+						this.logger.warn({
+							message: `Failed to schedule escalation job for incident ${createdIncident.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+							service: SERVICE_NAME,
+							method: "getMonitorJob",
+							stack: error instanceof Error ? error.stack : undefined,
+						});
+						// Don't throw - escalation failure shouldn't prevent incident creation
+					}
+				}
 			} catch (error: unknown) {
 				this.logger.warn({
 					message: error instanceof Error ? error.message : "Unknown error",
@@ -414,6 +446,83 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 					method: "getCleanupRetentionJob",
 					stack: error instanceof Error ? error.stack : undefined,
 				});
+			}
+		};
+	};
+
+	getEscalationJob = () => {
+		return async (data: { incidentId: string; monitorId: string; teamId: string }) => {
+			try {
+				const { incidentId, monitorId, teamId } = data;
+
+				this.logger.debug({
+					message: `Running escalation job for incident ${incidentId}`,
+					service: SERVICE_NAME,
+					method: "getEscalationJob",
+				});
+
+				// Fetch fresh incident to check state
+				const incident = await this.incidentsRepository.findById(incidentId, teamId);
+				if (!incident) {
+					this.logger.warn({
+						message: `Incident ${incidentId} not found`,
+						service: SERVICE_NAME,
+						method: "getEscalationJob",
+					});
+					return;
+				}
+
+				// Check if incident is still active (not yet resolved)
+				if (!incident.status) {
+					this.logger.debug({
+						message: `Incident ${incidentId} is already resolved, skipping escalation`,
+						service: SERVICE_NAME,
+						method: "getEscalationJob",
+					});
+					return;
+				}
+
+				// Check if escalation has already been sent (idempotency)
+				if (incident.escalationSentAt) {
+					this.logger.debug({
+						message: `Escalation already sent for incident ${incidentId} at ${incident.escalationSentAt}, skipping`,
+						service: SERVICE_NAME,
+						method: "getEscalationJob",
+					});
+					return;
+				}
+
+				// Fetch monitor to get escalation notification channels
+				const monitor = await this.monitorsRepository.findById(monitorId, teamId);
+				if (!monitor || !monitor.escalationNotifications || monitor.escalationNotifications.length === 0) {
+					this.logger.warn({
+						message: `Monitor ${monitorId} has no escalation notifications configured`,
+						service: SERVICE_NAME,
+						method: "getEscalationJob",
+					});
+					return;
+				}
+
+				// Send escalation notifications
+				await this.notificationsService.handleEscalationNotifications(monitor, incident);
+
+				// Update incident to mark escalation as sent
+				incident.escalationSentAt = new Date().toISOString();
+				await this.incidentsRepository.updateById(incidentId, teamId, incident);
+
+				this.logger.info({
+					message: `Escalation sent for incident ${incidentId}`,
+					service: SERVICE_NAME,
+					method: "getEscalationJob",
+				});
+			} catch (error: unknown) {
+				this.logger.error({
+					message: error instanceof Error ? error.message : "Unknown error during escalation",
+					service: SERVICE_NAME,
+					method: "getEscalationJob",
+					stack: error instanceof Error ? error.stack : undefined,
+				});
+				throw error;
 			}
 		};
 	};

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -1,4 +1,4 @@
-import type { HardwareStatusPayload, Monitor, MonitorStatusResponse } from "@/types/index.js";
+import type { HardwareStatusPayload, Monitor, MonitorStatusResponse, Incident } from "@/types/index.js";
 import type { MonitorActionDecision } from "@/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.js";
 import type {
 	NotificationMessage,
@@ -15,6 +15,7 @@ export interface INotificationMessageBuilder {
 		decision: MonitorActionDecision,
 		clientHost: string
 	): NotificationMessage;
+	buildEscalationMessage(monitor: Monitor, incident: Incident, clientHost: string): NotificationMessage;
 	extractThresholdBreaches(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): ThresholdBreach[];
 }
 
@@ -270,5 +271,77 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		}
 
 		return breaches;
+	}
+
+	buildEscalationMessage(monitor: Monitor, incident: Incident, clientHost: string): NotificationMessage {
+		const escalationMinutes = monitor.escalationAfterMinutes || 0;
+
+		return {
+			type: "monitor_down", // Use monitor_down type for escalation as it's also a down state
+			severity: "critical",
+			monitor: {
+				id: monitor.id,
+				name: monitor.name,
+				url: monitor.url,
+				type: monitor.type,
+				status: monitor.status,
+			},
+			content: this.buildEscalationContent(monitor, incident, escalationMinutes),
+			clientHost,
+			metadata: {
+				teamId: monitor.teamId,
+				notificationReason: "escalation",
+				isEscalation: true,
+				incidentId: incident.id,
+				escalationMinutes,
+			},
+		};
+	}
+
+	private buildEscalationContent(monitor: Monitor, incident: Incident, escalationMinutes: number): NotificationContent {
+		const downDuration = this.calculateDownDuration(incident.startTime);
+		const title = `🔔 [ESCALATION] Monitor ${monitor.name} Still Down`;
+		const summary = `Your monitor "${monitor.name}" has been down for ${escalationMinutes} minutes and escalation has been triggered.`;
+		const details = [
+			`URL: ${monitor.url}`,
+			`Status: Down`,
+			`Type: ${monitor.type}`,
+			`Down Since: ${new Date(incident.startTime).toISOString()}`,
+			`Down Duration: ${downDuration}`,
+			`Incident ID: ${incident.id}`,
+		];
+
+		if (incident.message) {
+			details.push(`Message: ${incident.message}`);
+		}
+
+		return {
+			title,
+			summary,
+			details,
+			timestamp: new Date(),
+		};
+	}
+
+	private calculateDownDuration(startTimeString: string): string {
+		try {
+			const startTime = new Date(startTimeString).getTime();
+			const nowTime = Date.now();
+			const durationMs = nowTime - startTime;
+
+			const hours = Math.floor(durationMs / (1000 * 60 * 60));
+			const minutes = Math.floor((durationMs % (1000 * 60 * 60)) / (1000 * 60));
+			const seconds = Math.floor((durationMs % (1000 * 60)) / 1000);
+
+			if (hours > 0) {
+				return `${hours}h ${minutes}m ${seconds}s`;
+			} else if (minutes > 0) {
+				return `${minutes}m ${seconds}s`;
+			} else {
+				return `${seconds}s`;
+			}
+		} catch {
+			return "Unknown";
+		}
 	}
 }

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -1,4 +1,4 @@
-import type { Monitor, MonitorStatusResponse, Notification } from "@/types/index.js";
+import type { Monitor, MonitorStatusResponse, Notification, Incident } from "@/types/index.js";
 import type { NotificationMessage } from "@/types/notificationMessage.js";
 import { IMonitorsRepository, INotificationsRepository } from "@/repositories/index.js";
 import { INotificationProvider } from "./notificationProviders/INotificationProvider.js";
@@ -14,7 +14,7 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
-
+	handleEscalationNotifications: (monitor: Monitor, incident: Incident) => Promise<boolean>;
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
 }
@@ -107,6 +107,42 @@ export class NotificationsService implements INotificationsService {
 		}
 	};
 
+	private sendEscalationToProvider = async (notification: Notification, escalationMessage: NotificationMessage | undefined): Promise<boolean> => {
+		if (!escalationMessage) {
+			this.logger.warn({
+				message: "Escalation message not provided",
+				service: SERVICE_NAME,
+				method: "sendEscalationToProvider",
+			});
+			return false;
+		}
+
+		// Route to provider based on notification type (same as regular notifications)
+		switch (notification.type) {
+			case "webhook":
+				return await this.webhookProvider.sendMessage!(notification, escalationMessage);
+			case "slack":
+				return await this.slackProvider.sendMessage!(notification, escalationMessage);
+			case "matrix":
+				return await this.matrixProvider.sendMessage!(notification, escalationMessage);
+			case "pager_duty":
+				return await this.pagerDutyProvider.sendMessage!(notification, escalationMessage);
+			case "discord":
+				return await this.discordProvider.sendMessage!(notification, escalationMessage);
+			case "email":
+				return await this.emailProvider.sendMessage!(notification, escalationMessage);
+			case "teams":
+				return await this.teamsProvider.sendMessage!(notification, escalationMessage);
+			default:
+				this.logger.warn({
+					message: `Unknown notification type: ${notification.type}`,
+					service: SERVICE_NAME,
+					method: "sendEscalationToProvider",
+				});
+				return false;
+		}
+	};
+
 	private sendNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
 		const notificationIds = monitor.notifications ?? [];
 		const notifications = await this.notificationsRepository.findNotificationsByIds(notificationIds);
@@ -139,6 +175,70 @@ export class NotificationsService implements INotificationsService {
 
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	handleEscalationNotifications = async (monitor: Monitor, incident: Incident): Promise<boolean> => {
+		const escallationNotificationIds = monitor.escalationNotifications ?? [];
+		if (escallationNotificationIds.length === 0) {
+			this.logger.warn({
+				message: `Monitor ${monitor.id} has no escalation notifications configured`,
+				service: SERVICE_NAME,
+				method: "handleEscalationNotifications",
+			});
+			return false;
+		}
+
+		const notifications = await this.notificationsRepository.findNotificationsByIds(escallationNotificationIds);
+		if (notifications.length === 0) {
+			this.logger.warn({
+				message: `No escalation notifications found for monitor ${monitor.id}`,
+				service: SERVICE_NAME,
+				method: "handleEscalationNotifications",
+			});
+			return false;
+		}
+
+		// Build escalation-specific message
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+		const escalationMessage = this.notificationMessageBuilder.buildEscalationMessage(monitor, incident, clientHost);
+
+		// Send escalation to each notification channel
+		const tasks = notifications.map(async (notification) => {
+			try {
+				const result = await this.sendEscalationToProvider(notification, escalationMessage);
+				return result;
+			} catch (error: unknown) {
+				this.logger.error({
+					message: `Error sending escalation notification: ${error instanceof Error ? error.message : "Unknown error"}`,
+					service: SERVICE_NAME,
+					method: "handleEscalationNotifications",
+					stack: error instanceof Error ? error.stack : undefined,
+				});
+				return false;
+			}
+		});
+
+		const outcomes = await Promise.all(tasks);
+		const succeeded = outcomes.filter(Boolean).length;
+		const failed = outcomes.length - succeeded;
+
+		if (failed > 0) {
+			this.logger.warn({
+				message: `Escalation notification send completed with ${succeeded} success, ${failed} failure(s)`,
+				service: SERVICE_NAME,
+				method: "handleEscalationNotifications",
+			});
+		} else {
+			this.logger.info({
+				message: `Escalation notification sent successfully to ${succeeded} channel(s)`,
+				service: SERVICE_NAME,
+				method: "handleEscalationNotifications",
+			});
+		}
+
+		// Return true if at least one notification succeeded
+		return succeeded > 0;
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -16,6 +16,8 @@ export interface Incident {
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;
 	comment?: string | null;
+	escalationTriggeredAt?: string | null;
+	escalationSentAt?: string | null;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -37,6 +37,8 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationAfterMinutes?: number | null;
+	escalationNotifications: string[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -89,6 +89,8 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalationAfterMinutes: z.number().min(1).max(1440).nullable().optional(),
+	escalationNotifications: z.array(z.string()).optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),


### PR DESCRIPTION
Implemented escalated notifications per project spec:

- Added escalation settings to monitor (frontend + backend)
- Persisted escalation data
- Implemented time-based escalation email trigger
- Tested using Render service (down/up simulation)

Includes:
- Working email notifications
- Escalation after defined duration