### PR TITLE
Add Escalation Notifications

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -17,6 +17,10 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,
 	geoCheckLocations: data?.geoCheckLocations || [],
 	geoCheckInterval: data?.geoCheckInterval || 300000,
+	escalation: data?.escalation ?? {
+		delayMinutes: 30,
+		channelId: "",
+	},
 });
 
 export const useMonitorForm = ({

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -765,6 +765,69 @@ const CreateMonitorPage = () => {
 				}
 			/>
 
+			<ConfigBox
+			title={t("pages.createMonitor.form.escalations.title")}
+			subtitle={t("pages.createMonitor.form.escalations.description")}
+			rightContent={
+				<Controller
+					name="escalation"
+					control={control}
+					render={({ field }) => {
+					const escalation = field.value ?? {
+						delayMinutes: 30,
+						channelId: "",
+					};
+					const notificationOptions = (notifications ?? []).map((n) => ({
+						...n,
+						name: n.notificationName,
+					}));
+					const selectedChannel = notificationOptions.find(
+						(option) => option.id === escalation.channelId
+					) ?? null;
+
+					return (
+						<Stack spacing={theme.spacing(LAYOUT.MD)}>
+							<TextField
+								type="number"
+								label={t(
+									"pages.createMonitor.form.escalations.option.delay.label"
+								)}
+								value={escalation.delayMinutes}
+								onChange={(e) => {
+									const delayMinutes = Math.max(
+										1,
+										parseInt(e.target.value, 10) || 1
+									);
+									field.onChange({ ...escalation, delayMinutes });
+								}}
+								inputProps={{ min: 1, step: 1 }}
+								fullWidth
+							/>
+							<Autocomplete
+								options={notificationOptions}
+								value={selectedChannel}
+								getOptionLabel={(option) => option.name}
+								onChange={(_: unknown, newValue) => {
+									field.onChange({
+										...escalation,
+										channelId:
+											(newValue as typeof notificationOptions[number] | null)
+												?.id ?? "",
+									});
+								}}
+								isOptionEqualToValue={(option, value) =>
+									option.id === value?.id
+								}
+								fieldLabel={t(
+									"pages.createMonitor.form.escalations.option.channel.label"
+								)}
+							/>
+						</Stack>
+					);
+				}}
+				/>
+			}
+		/>
 			{(watchedType === "http" ||
 				watchedType === "grpc" ||
 				watchedType === "websocket") && (
@@ -1044,6 +1107,7 @@ const CreateMonitorPage = () => {
 				/>
 			)}
 
+			
 			<Stack
 				direction="row"
 				justifyContent="flex-end"

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface EscalationRule {
+	delayMinutes: number;
+	channelId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -76,6 +81,7 @@ export interface Monitor {
 	geoCheckEnabled?: boolean;
 	geoCheckLocations?: GeoContinent[];
 	geoCheckInterval?: number;
+	escalation?: EscalationRule;
 	recentChecks: CheckSnapshot[];
 	createdAt: string;
 	updatedAt: string;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -27,6 +27,10 @@ const baseSchema = z.object({
 		.number()
 		.min(300000, "Interval must be at least 5 minutes")
 		.optional(),
+	escalation: z.object({
+		delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+		channelId: z.string().min(1, "Channel is required"),
+	}),
 });
 
 // HTTP monitor schema

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -602,6 +602,18 @@
 						}
 					}
 				},
+				"escalations": {
+					"title": "Escalation Rules",
+					"description": "If the monitor stays down for the specified time, notify an additional channel.",
+					"option": {
+						"delay": {
+							"label": "Escalate after (minutes)"
+						},
+						"channel": {
+							"label": "Escalation notification channel"
+						}
+					}
+				},
 				"url": {
 					"title": "Monitor IP/URL on Status Page",
 					"description": "Display the IP address or URL of monitor on the public Status page. If it's disabled, only the monitor name will be shown to protect sensitive information.",

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -72,6 +72,10 @@ const IncidentSchema = new Schema<IncidentDocument>(
 			type: String,
 			default: null,
 		},
+		sentEscalations: {
+			type: [Number],
+			default: [],
+		},
 	},
 	{ timestamps: true }
 );

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -18,12 +18,16 @@ type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Dat
 
 type MonitorDocumentBase = Omit<
 	Monitor,
-	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
+	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "escalation" | "createdAt" | "updatedAt"
 > & {
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
 	selectedDisks: string[];
+	escalation?: {
+		delayMinutes: number;
+		channelId: Types.ObjectId;
+	};
 	matchMethod?: MonitorMatchMethod;
 };
 
@@ -350,6 +354,21 @@ const MonitorSchema = new Schema<MonitorDocument>(
 		geoCheckInterval: {
 			type: Number,
 			default: 300000,
+		},
+		escalation: {
+			type: {
+				delayMinutes: {
+					type: Number,
+					required: false,
+				},
+				channelId: {
+					type: Schema.Types.ObjectId,
+					ref: "Notification",
+					required: false,
+				},
+				_id: false,
+			},
+			default: undefined,
 		},
 		recentChecks: {
 			type: [checkSnapshotSchema],

--- a/server/src/repositories/incidents/MongoIncidentRepository.ts
+++ b/server/src/repositories/incidents/MongoIncidentRepository.ts
@@ -60,6 +60,7 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			resolvedBy: doc.resolvedBy ? this.toStringId(doc.resolvedBy) : null,
 			resolvedByEmail: doc.resolvedByEmail ?? null,
 			comment: doc.comment ?? null,
+			sentEscalations: doc.sentEscalations ?? [],
 			createdAt: this.toDateString(doc.createdAt),
 			updatedAt: this.toDateString(doc.updatedAt),
 		};

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -391,6 +391,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+		escalation: doc.escalation ? {
+			delayMinutes: doc.escalation.delayMinutes,
+			channelId: doc.escalation.channelId?.toString() ?? "",
+		} : undefined,
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};
@@ -448,8 +452,13 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			group: doc.group ?? null,
 			recentChecks: (doc.recentChecks ?? []).map((check: CheckSnapshotDocument) => this.toCheckSnapshot(check)),
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
-			geoCheckLocations: doc.geoCheckLocations ?? [],
-			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+
+		geoCheckLocations: doc.geoCheckLocations ?? [],
+		geoCheckInterval: doc.geoCheckInterval ?? 300000,
+		escalation: doc.escalation ? {
+			delayMinutes: doc.escalation.delayMinutes,
+			channelId: doc.escalation.channelId?.toString() ?? "",
+		} : undefined,
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -177,6 +177,16 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 						stack: error instanceof Error ? error.stack : undefined,
 					});
 				});
+
+				// Step 8. Handle escalations (best effort, don't wait)
+				this.handleEscalations(statusChangeResult.monitor, statusChangeResult.statusChanged, status.status).catch((error: unknown) => {
+					this.logger.warn({
+						message: `Error handling escalations for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+						service: SERVICE_NAME,
+						method: "getMonitorJob",
+						stack: error instanceof Error ? error.stack : undefined,
+					});
+				});
 			} catch (error: unknown) {
 				this.logger.warn({
 					message: error instanceof Error ? error.message : "Unknown error",
@@ -417,6 +427,153 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 			}
 		};
 	};
+
+	private async handleEscalations(monitor: Monitor, statusChanged: boolean, currentCheckStatus: boolean): Promise<void> {
+		// Exit early if no escalation rule
+		if (!monitor.escalation) {
+			this.logger.debug({
+				message: `Monitor ${monitor.id} has no escalation rule, skipping`,
+				service: SERVICE_NAME,
+				method: "handleEscalations",
+			});
+			return;
+		}
+
+		// Only process if current check status is failed (false)
+		if (currentCheckStatus !== false) {
+			this.logger.debug({
+				message: `Monitor ${monitor.id} check status is not failed, skipping escalations`,
+				service: SERVICE_NAME,
+				method: "handleEscalations",
+			});
+			return;
+		}
+
+		// Skip if status just changed (avoid immediate escalation)
+		if (statusChanged) {
+			this.logger.debug({
+				message: `Monitor ${monitor.id} status just changed, skipping escalations`,
+				service: SERVICE_NAME,
+				method: "handleEscalations",
+			});
+			return;
+		}
+
+		// Ensure monitor status is currently "down"
+		if (monitor.status !== "down") {
+			this.logger.debug({
+				message: `Monitor ${monitor.id} status is not 'down', current status: ${monitor.status}, skipping escalations`,
+				service: SERVICE_NAME,
+				method: "handleEscalations",
+			});
+			return;
+		}
+
+		// Fetch the active incident for the monitor
+		const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId);
+
+		// Exit if no active incident exists
+		if (!activeIncident) {
+			this.logger.debug({
+				message: `Monitor ${monitor.id} has no active incident, skipping escalations`,
+				service: SERVICE_NAME,
+				method: "handleEscalations",
+			});
+			return;
+		}
+
+		// Exit if incident is acknowledged
+		if (activeIncident.status === false) {
+			this.logger.debug({
+				message: `Monitor ${monitor.id} incident is acknowledged/resolved, skipping escalations`,
+				service: SERVICE_NAME,
+				method: "handleEscalations",
+			});
+			return;
+		}
+
+		// Compute how long the incident has been active (in minutes)
+		const startTime = new Date(activeIncident.startTime);
+		const now = new Date();
+		const incidentDurationMs = now.getTime() - startTime.getTime();
+		const incidentDurationMinutes = Math.floor(incidentDurationMs / (1000 * 60));
+
+		this.logger.debug({
+			message: `Monitor ${monitor.id} incident duration: ${incidentDurationMinutes} minutes`,
+			service: SERVICE_NAME,
+			method: "handleEscalations",
+		});
+
+		// Initialize or get sentEscalations array
+		if (!activeIncident.sentEscalations) {
+			activeIncident.sentEscalations = [];
+		}
+
+		// Check if the escalation rule should trigger
+		const rule = monitor.escalation;
+		if (incidentDurationMinutes >= rule.delayMinutes && !activeIncident.sentEscalations.includes(rule.delayMinutes)) {
+			this.logger.info({
+				message: `Escalation triggered for monitor ${monitor.id} at ${rule.delayMinutes} minutes delay`,
+				service: SERVICE_NAME,
+				method: "handleEscalations",
+				details: { channelId: rule.channelId, durationMinutes: incidentDurationMinutes },
+			});
+
+			// Send escalation notification
+			this.notificationsService
+				.sendEscalationNotification(monitor, activeIncident, rule.channelId, rule.delayMinutes)
+				.then((success) => {
+					if (success) {
+						this.logger.info({
+							message: `Escalation notification sent for monitor ${monitor.id}`,
+							service: SERVICE_NAME,
+							method: "handleEscalations",
+							details: { channelId: rule.channelId, delayMinutes: rule.delayMinutes },
+						});
+					} else {
+						this.logger.warn({
+							message: `Failed to send escalation notification for monitor ${monitor.id}`,
+							service: SERVICE_NAME,
+							method: "handleEscalations",
+							details: { channelId: rule.channelId, delayMinutes: rule.delayMinutes },
+						});
+					}
+				})
+				.catch((error: unknown) => {
+					this.logger.error({
+						message: `Error sending escalation notification for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+						service: SERVICE_NAME,
+						method: "handleEscalations",
+						stack: error instanceof Error ? error.stack : undefined,
+					});
+				});
+
+			// Track that this escalation has been sent
+			activeIncident.sentEscalations.push(rule.delayMinutes);
+		}
+
+		// Persist the updated sentEscalations array back to the database
+		if (activeIncident.sentEscalations.length > 0) {
+			try {
+				await this.incidentsRepository.updateById(activeIncident.id, monitor.teamId, {
+					sentEscalations: activeIncident.sentEscalations,
+				});
+				this.logger.debug({
+					message: `Updated incident escalation tracking for monitor ${monitor.id}`,
+					service: SERVICE_NAME,
+					method: "handleEscalations",
+					details: { sentEscalations: activeIncident.sentEscalations },
+				});
+			} catch (error: unknown) {
+				this.logger.error({
+					message: `Error updating incident sentEscalations for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+					service: SERVICE_NAME,
+					method: "handleEscalations",
+					stack: error instanceof Error ? error.stack : undefined,
+				});
+			}
+		}
+	}
 
 	private evaluateMonitorAction(statusChangeResult: StatusChangeResult): MonitorActionDecision {
 		const { monitor, statusChanged, prevStatus } = statusChangeResult;

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -7,6 +7,7 @@ import type {
 	ThresholdBreach,
 	NotificationContent,
 } from "@/types/notificationMessage.js";
+import type { Incident } from "@/types/index.js";
 
 export interface INotificationMessageBuilder {
 	buildMessage(
@@ -15,6 +16,7 @@ export interface INotificationMessageBuilder {
 		decision: MonitorActionDecision,
 		clientHost: string
 	): NotificationMessage;
+	buildEscalationMessage(monitor: Monitor, incident: Incident, clientHost: string, delayMinutes: number): NotificationMessage;
 	extractThresholdBreaches(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): ThresholdBreach[];
 }
 
@@ -271,4 +273,53 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 
 		return breaches;
 	}
-}
+
+	public buildEscalationMessage(monitor: Monitor, incident: Incident, clientHost: string, delayMinutes: number): NotificationMessage {
+		const incidentStartTime = new Date(incident.startTime);
+		const incidentDuration = this.formatDuration(new Date(), incidentStartTime);
+
+		const content: NotificationContent = {
+			title: `Escalation: Monitor ${monitor.name} is still down`,
+			summary: `The server has remained down for ${delayMinutes} minutes.`,
+			details: [
+				`Monitor: ${monitor.name}`,
+				`URL: ${monitor.url}`,
+				`Status: Down`,
+				`Started: ${incidentStartTime.toISOString()}`,
+				`Duration: ${incidentDuration}`,
+				incident.message ? `Error: ${incident.message}` : undefined,
+			].filter(Boolean) as string[],
+			timestamp: new Date(),
+		};
+
+		return {
+			type: "escalation",
+			severity: "critical",
+			monitor: {
+				id: monitor.id,
+				name: monitor.name,
+				url: monitor.url,
+				type: monitor.type,
+				status: monitor.status,
+			},
+			content,
+			clientHost,
+			metadata: {
+				teamId: monitor.teamId,
+				notificationReason: "escalation",
+			},
+		};
+	}
+
+	private formatDuration(endTime: Date, startTime: Date): string {
+		const ms = endTime.getTime() - startTime.getTime();
+		const totalSeconds = Math.floor(ms / 1000);
+		const hours = Math.floor(totalSeconds / 3600);
+		const minutes = Math.floor((totalSeconds % 3600) / 60);
+		const seconds = totalSeconds % 60;
+
+		if (hours > 0) {
+			return `${hours}h ${minutes}m`;
+		}
+		return `${minutes}m ${seconds}s`;
+	}}

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -87,6 +87,8 @@ export class EmailProvider implements INotificationProvider {
 				return `Monitor ${message.monitor.name} threshold exceeded`;
 			case "threshold_resolved":
 				return `Monitor ${message.monitor.name} thresholds resolved`;
+			case "escalation":
+				return `Escalation: Monitor ${message.monitor.name} still down`;
 			default:
 				return `Alert: ${message.monitor.name}`;
 		}

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -1,4 +1,4 @@
-import type { Monitor, MonitorStatusResponse, Notification } from "@/types/index.js";
+import type { Monitor, MonitorStatusResponse, Notification, Incident } from "@/types/index.js";
 import type { NotificationMessage } from "@/types/notificationMessage.js";
 import { IMonitorsRepository, INotificationsRepository } from "@/repositories/index.js";
 import { INotificationProvider } from "./notificationProviders/INotificationProvider.js";
@@ -14,6 +14,7 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	sendEscalationNotification: (monitor: Monitor, incident: Incident, channelId: string, delayMinutes: number) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -139,6 +140,55 @@ export class NotificationsService implements INotificationsService {
 
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	sendEscalationNotification = async (monitor: Monitor, incident: Incident, channelId: string, delayMinutes: number): Promise<boolean> => {
+		try {
+			// Find the notification channel by ID
+			const notification = await this.notificationsRepository.findById(channelId, monitor.teamId);
+
+			if (!notification) {
+				this.logger.warn({
+					message: `Escalation notification channel not found: ${channelId}`,
+					service: SERVICE_NAME,
+					method: "sendEscalationNotification",
+				});
+				return false;
+			}
+
+			// Build escalation message
+			const settings = this.settingsService.getSettings();
+			const clientHost = settings.clientHost || "Host not defined";
+			const notificationMessage = this.notificationMessageBuilder.buildEscalationMessage(monitor, incident, clientHost, delayMinutes);
+
+			const placeholderMonitorStatusResponse: MonitorStatusResponse = {
+				monitorId: monitor.id,
+				teamId: monitor.teamId,
+				type: monitor.type,
+				status: monitor.status === "up",
+				code: 0,
+				message: "",
+			};
+
+			const placeholderDecision: MonitorActionDecision = {
+				shouldCreateIncident: false,
+				shouldResolveIncident: false,
+				shouldSendNotification: false,
+				incidentReason: null,
+				notificationReason: null,
+			};
+
+			// Send through the escalation channel
+			return await this.send(notification, monitor, placeholderMonitorStatusResponse, placeholderDecision, notificationMessage);
+		} catch (error: unknown) {
+			this.logger.error({
+				message: `Error sending escalation notification: ${error instanceof Error ? error.message : "Unknown error"}`,
+				service: SERVICE_NAME,
+				method: "sendEscalationNotification",
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+			return false;
+		}
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -16,6 +16,7 @@ export interface Incident {
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;
 	comment?: string | null;
+	sentEscalations: number[];
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface EscalationRule {
+	delayMinutes: number;
+	channelId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -53,6 +58,7 @@ export interface Monitor {
 	geoCheckEnabled?: boolean;
 	geoCheckLocations?: GeoContinent[];
 	geoCheckInterval?: number;
+	escalation?: EscalationRule;
 	recentChecks: CheckSnapshot[];
 	createdAt: string;
 	updatedAt: string;

--- a/server/src/types/notificationMessage.ts
+++ b/server/src/types/notificationMessage.ts
@@ -3,7 +3,7 @@
  * Part of notification system unification effort
  */
 
-export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test";
+export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "escalation" | "test";
 
 export type NotificationSeverity = "critical" | "warning" | "info" | "success";
 

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -78,6 +78,10 @@ export const createMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalation: z.object({
+		delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+		channelId: z.string().min(1, "Channel ID is required"),
+	}).optional(),
 });
 
 export const editMonitorBodyValidation = z.object({
@@ -107,6 +111,10 @@ export const editMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalation: z.object({
+		delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+		channelId: z.string().min(1, "Channel ID is required"),
+	}).optional(),
 });
 
 export const pauseMonitorParamValidation = z.object({
@@ -160,6 +168,10 @@ const importedMonitorSchema = z.object({
 	geoCheckEnabled: z.boolean().default(false),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).default([]),
 	geoCheckInterval: z.number().min(300000).default(300000),
+	escalation: z.object({
+		delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+		channelId: z.string().min(1, "Channel ID is required"),
+	}).optional(),
 	createdAt: z.string().optional(),
 	updatedAt: z.string().optional(),
 });


### PR DESCRIPTION
## Changes

Implemented a notification escalation system for monitors, allowing users to input a delay (in minutes) and a notification channel to be notified if a monitor remains down without being acknowledged for the specified amount of time.

- Added escalation fields to monitor creation/configuration
- Updated backend to support storing and retrieving escalation settings
- Ensured escalation data persisted after saving and reloading
- Implemented escalation logic in the notification/queue system to trigger alerts after the specified delay
- Updated email notification formatting to include unique escalation subject and body elements

Fixes #1 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

