### PR TITLE
feat: add escalated notifications for monitors

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalations: data?.escalations || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useEffect } from "react";
 import { logger } from "@/Utils/logger";
 import { useParams, useLocation, useNavigate } from "react-router";
-import { useForm, Controller } from "react-hook-form";
+import { useForm, Controller, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTheme } from "@mui/material";
 import Stack from "@mui/material/Stack";
@@ -39,6 +39,9 @@ import {
 	supportsGeoCheck,
 } from "@/Types/Monitor";
 import type { Notification } from "@/Types/Notification";
+import { NotificationChannels } from "@/Types/Notification";
+import type { EscalationRule } from "@/Types/Monitor";
+import MuiTextField from "@mui/material/TextField";
 import type { MonitorFormData } from "@/Validation/monitor";
 
 interface GeneralSettingsConfig {
@@ -203,6 +206,11 @@ const CreateMonitorPage = () => {
 		defaultValues: defaults,
 	});
 	const { control, watch, handleSubmit, clearErrors } = form;
+
+	const { fields: escalationFields, append: appendEscalation, remove: removeEscalation } = useFieldArray({
+		control,
+		name: "escalations" as never,
+	});
 
 	useEffect(() => {
 		form.reset(defaults);
@@ -762,6 +770,78 @@ const CreateMonitorPage = () => {
 							);
 						}}
 					/>
+				}
+			/>
+
+			<ConfigBox
+				title="Escalated Notifications"
+				subtitle="Send alerts to specific notification channels after an incident has been active for a set duration."
+				rightContent={
+					<Stack spacing={theme.spacing(LAYOUT.MD)}>
+						{(escalationFields as EscalationRule[]).map((_, index) => (
+							<Stack
+								key={index}
+								direction="row"
+								alignItems="center"
+								spacing={theme.spacing(SPACING.LG)}
+								width="100%"
+							>
+								<Controller
+									name={`escalations.${index}.delayMinutes` as never}
+									control={control}
+									render={({ field: f }) => (
+										<MuiTextField
+											{...f}
+											label="Delay (minutes)"
+											type="number"
+											size="small"
+											inputProps={{ min: 1 }}
+											sx={{ width: 160 }}
+											onChange={(e) => f.onChange(Number(e.target.value))}
+										/>
+									)}
+								/>
+								<Controller
+									name={`escalations.${index}.notificationType` as never}
+									control={control}
+									render={({ field: f }) => {
+										const typeOptions = NotificationChannels.map((ch) => ({
+											id: ch,
+											name: ch.charAt(0).toUpperCase() + ch.slice(1).replace("_", " "),
+										}));
+										const selected = typeOptions.find((o) => o.id === f.value) ?? null;
+										return (
+											<Autocomplete
+												options={typeOptions}
+												value={selected}
+												getOptionLabel={(option) => option.name}
+												onChange={(_: unknown, newVal: typeof typeOptions[0] | null) => {
+													f.onChange(newVal?.id ?? "");
+												}}
+												isOptionEqualToValue={(option, value) => option.id === value.id}
+												sx={{ flex: 1, minWidth: 160 }}
+											/>
+										);
+									}}
+								/>
+								<IconButton
+									size="small"
+									onClick={() => removeEscalation(index)}
+									aria-label="Remove escalation rule"
+								>
+									<Trash2 size={16} />
+								</IconButton>
+							</Stack>
+						))}
+						<Button
+							variant="outlined"
+							color="secondary"
+							onClick={() => appendEscalation({ delayMinutes: 30, notificationType: "" } as never)}
+							sx={{ alignSelf: "flex-start" }}
+						>
+							+ Add escalation rule
+						</Button>
+					</Stack>
 				}
 			/>
 

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -1,3 +1,9 @@
+
+// Added Escalation Rule
+
+
+
+
 import type { GroupedCheck, CheckSnapshot } from "@/Types/Check";
 import type { PageSpeedGroupedCheck } from "@/Types/Check";
 import type { GeoContinent } from "@/Types/GeoCheck";
@@ -38,6 +44,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface EscalationRule {
+	delayMinutes: number;
+	notificationType: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +71,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalations: EscalationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -13,6 +13,14 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalations: z
+		.array(
+			z.object({
+				delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+				notificationType: z.string().min(1, "Notification type is required"),
+			})
+		)
+		.optional(),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepare": "husky"
+    "prepare": "husky",
+    "dev": "docker compose -f docker/dev/docker-compose.yaml up -d && npm --prefix server install && npm --prefix client install && (npm --prefix server run dev & npm --prefix client run dev)"
   },
   "repository": {
     "type": "git",

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -1,12 +1,21 @@
+
+//added use field array
+
+
+
+
+
+
 import { Schema, model, type Types } from "mongoose";
 import { IncidentResolutionTypes, type Incident } from "@/types/incident.js";
 
-type IncidentDocumentBase = Omit<Incident, "id" | "monitorId" | "teamId" | "resolvedBy" | "startTime" | "endTime" | "createdAt" | "updatedAt"> & {
+type IncidentDocumentBase = Omit<Incident, "id" | "monitorId" | "teamId" | "resolvedBy" | "startTime" | "endTime" | "firedEscalations" | "createdAt" | "updatedAt"> & {
 	monitorId: Types.ObjectId;
 	teamId: Types.ObjectId;
 	resolvedBy?: Types.ObjectId | null;
 	startTime: Date;
 	endTime: Date | null;
+	firedEscalations: number[];
 	createdAt: Date;
 	updatedAt: Date;
 };
@@ -71,6 +80,10 @@ const IncidentSchema = new Schema<IncidentDocument>(
 		comment: {
 			type: String,
 			default: null,
+		},
+		firedEscalations: {
+			type: [Number],
+			default: [],
 		},
 	},
 	{ timestamps: true }

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -1,3 +1,9 @@
+
+//added escalations array to mongose schema
+
+
+
+
 import { Schema, model, Types } from "mongoose";
 import type { Monitor, MonitorMatchMethod, CheckSnapshot } from "@/types/monitor.js";
 import { MonitorTypes, MonitorStatuses } from "@/types/monitor.js";
@@ -18,11 +24,12 @@ type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Dat
 
 type MonitorDocumentBase = Omit<
 	Monitor,
-	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
+	"id" | "userId" | "teamId" | "notifications" | "escalations" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
 > & {
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
+	escalations: { delayMinutes: number; notificationId: Types.ObjectId }[];
 	selectedDisks: string[];
 	matchMethod?: MonitorMatchMethod;
 };
@@ -282,6 +289,12 @@ const MonitorSchema = new Schema<MonitorDocument>(
 			{
 				type: Schema.Types.ObjectId,
 				ref: "Notification",
+			},
+		],
+		escalations: [
+			{
+				delayMinutes: { type: Number, required: true },
+				notificationType: { type: String, required: true },
 			},
 		],
 		secret: {

--- a/server/src/repositories/incidents/IIncidentsRepository.ts
+++ b/server/src/repositories/incidents/IIncidentsRepository.ts
@@ -22,6 +22,7 @@ export interface IIncidentsRepository {
 
 	// update
 	updateById(incidentId: string, teamId: string, updateData: Partial<Incident>): Promise<Incident>;
+	addFiredEscalation(incidentId: string, delayMinutes: number): Promise<void>;
 	// delete
 	deleteByMonitorId(monitorId: string, teamId: string): Promise<number>;
 	deleteByMonitorIdsNotIn(monitorIds: string[]): Promise<number>;

--- a/server/src/repositories/incidents/MongoIncidentRepository.ts
+++ b/server/src/repositories/incidents/MongoIncidentRepository.ts
@@ -60,6 +60,7 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			resolvedBy: doc.resolvedBy ? this.toStringId(doc.resolvedBy) : null,
 			resolvedByEmail: doc.resolvedByEmail ?? null,
 			comment: doc.comment ?? null,
+			firedEscalations: doc.firedEscalations ?? [],
 			createdAt: this.toDateString(doc.createdAt),
 			updatedAt: this.toDateString(doc.updatedAt),
 		};
@@ -147,6 +148,13 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			throw new AppError({ message: `Failed to update incident with id ${incidentId}`, status: 500 });
 		}
 		return this.toEntity(updatedIncident);
+	};
+
+	addFiredEscalation = async (incidentId: string, delayMinutes: number): Promise<void> => {
+		await IncidentModel.updateOne(
+			{ _id: new mongoose.Types.ObjectId(incidentId) },
+			{ $addToSet: { firedEscalations: delayMinutes } }
+		);
 	};
 
 	countByTeamId = async (

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -351,6 +351,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification) => toStringId(notification));
+		const escalations = (doc.escalations ?? []).map((e) => ({
+			delayMinutes: e.delayMinutes,
+			notificationType: e.notificationType ?? "",
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -374,6 +378,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalations,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -410,6 +415,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification: unknown) => toStringId(notification));
+		const escalations = (doc.escalations ?? []).map((e: { delayMinutes: number; notificationType: string }) => ({
+			delayMinutes: e.delayMinutes,
+			notificationType: e.notificationType ?? "",
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -433,6 +442,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalations,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -1,3 +1,10 @@
+
+
+// added step 8
+
+
+
+
 const SERVICE_NAME = "JobQueueHelper";
 import type { Monitor } from "@/types/monitor.js";
 import { supportsGeoCheck } from "@/types/monitor.js";
@@ -11,7 +18,7 @@ import {
 	IncidentService,
 	type IGeoChecksService,
 } from "@/service/index.js";
-import { CHECK_TTL_SENTINEL, type MaintenanceWindow, type StatusChangeResult } from "@/types/index.js";
+import { CHECK_TTL_SENTINEL, type MaintenanceWindow, type StatusChangeResult, type MonitorStatusResponse } from "@/types/index.js";
 import {
 	IMaintenanceWindowsRepository,
 	IMonitorsRepository,
@@ -171,7 +178,17 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 				// Step 7. Handle incidents (best effort, don't wait)
 				this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status).catch((error: unknown) => {
 					this.logger.warn({
-						message: `Error handling incident for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+						message: `Error handling incident for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+						service: SERVICE_NAME,
+						method: "getMonitorJob",
+						stack: error instanceof Error ? error.stack : undefined,
+					});
+				});
+
+				// Step 8. Check escalated notifications (best effort, don't wait)
+				this.checkEscalations(statusChangeResult.monitor, status, decision).catch((error: unknown) => {
+					this.logger.warn({
+						message: `Error checking escalations for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
 						service: SERVICE_NAME,
 						method: "getMonitorJob",
 						stack: error instanceof Error ? error.stack : undefined,
@@ -416,6 +433,80 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 				});
 			}
 		};
+	};
+
+	private checkEscalations = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision): Promise<void> => {
+		// Only check escalations when monitor is actively down or breached
+		this.logger.debug({
+			message: `[Escalation] Checking monitor ${monitor.id} status=${monitor.status} escalations=${JSON.stringify(monitor.escalations)}`,
+			service: SERVICE_NAME,
+			method: "checkEscalations",
+		});
+
+		if (monitor.status !== "down" && monitor.status !== "breached") {
+			this.logger.debug({
+				message: `[Escalation] Skipping — monitor status is "${monitor.status}", not down/breached`,
+				service: SERVICE_NAME,
+				method: "checkEscalations",
+			});
+			return;
+		}
+
+		const escalations = monitor.escalations ?? [];
+		if (escalations.length === 0) {
+			this.logger.debug({
+				message: `[Escalation] Skipping — no escalation rules configured`,
+				service: SERVICE_NAME,
+				method: "checkEscalations",
+			});
+			return;
+		}
+
+		const incident = await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId);
+		if (!incident) {
+			this.logger.debug({
+				message: `[Escalation] Skipping — no active incident found for monitor ${monitor.id}`,
+				service: SERVICE_NAME,
+				method: "checkEscalations",
+			});
+			return;
+		}
+
+		const incidentStartMs = new Date(incident.startTime).getTime();
+		const nowMs = Date.now();
+		const elapsedMinutes = ((nowMs - incidentStartMs) / 60000).toFixed(2);
+		const firedEscalations = incident.firedEscalations ?? [];
+
+		this.logger.debug({
+			message: `[Escalation] Incident active for ${elapsedMinutes} min, firedEscalations=${JSON.stringify(firedEscalations)}`,
+			service: SERVICE_NAME,
+			method: "checkEscalations",
+		});
+
+		for (const rule of escalations) {
+			const thresholdMs = rule.delayMinutes * 60 * 1000;
+			const alreadyFired = firedEscalations.includes(rule.delayMinutes);
+
+			this.logger.debug({
+				message: `[Escalation] Rule: delay=${rule.delayMinutes}min type=${rule.notificationType} alreadyFired=${alreadyFired} elapsed=${elapsedMinutes}min`,
+				service: SERVICE_NAME,
+				method: "checkEscalations",
+			});
+
+			if (!alreadyFired && nowMs - incidentStartMs >= thresholdMs) {
+				// Mark as fired before sending to prevent duplicate sends
+				await this.incidentsRepository.addFiredEscalation(incident.id, rule.delayMinutes);
+
+				// Send escalation notification
+				await this.notificationsService.sendEscalatedNotification(monitor, monitorStatusResponse, decision, rule.notificationType, rule.delayMinutes);
+
+				this.logger.info({
+					message: `[Escalation] Fired for monitor ${monitor.id} at ${rule.delayMinutes} minutes via ${rule.notificationType}`,
+					service: SERVICE_NAME,
+					method: "checkEscalations",
+				});
+			}
+		}
 	};
 
 	private evaluateMonitorAction(statusChangeResult: StatusChangeResult): MonitorActionDecision {

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -1,3 +1,7 @@
+// made sendEscalatedNotification()
+
+
+
 import type { Monitor, MonitorStatusResponse, Notification } from "@/types/index.js";
 import type { NotificationMessage } from "@/types/notificationMessage.js";
 import { IMonitorsRepository, INotificationsRepository } from "@/repositories/index.js";
@@ -14,6 +18,7 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	sendEscalatedNotification: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision, notificationId: string, delayMinutes: number) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -139,6 +144,49 @@ export class NotificationsService implements INotificationsService {
 
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	sendEscalatedNotification = async (
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		decision: MonitorActionDecision,
+		notificationType: string,
+		delayMinutes: number
+	): Promise<boolean> => {
+		const allTeamNotifications = await this.notificationsRepository.findByTeamId(monitor.teamId);
+		const notifications = allTeamNotifications.filter((n) => n.type === notificationType);
+		if (!notifications.length) {
+			this.logger.warn({
+				message: `No escalation notifications of type "${notificationType}" found for team ${monitor.teamId}`,
+				service: SERVICE_NAME,
+				method: "sendEscalatedNotification",
+			});
+			return false;
+		}
+
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+
+		// Build an escalation-specific decision so the message reads as "still down"
+		const escalationDecision: MonitorActionDecision = {
+			...decision,
+			shouldSendNotification: true,
+			notificationReason: "status_change",
+		};
+
+		const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, escalationDecision, clientHost);
+
+		// Append escalation context to the message summary
+		if (notificationMessage?.content) {
+			notificationMessage.content.summary = `[Escalation: ${delayMinutes} min] ${notificationMessage.content.summary}`;
+		}
+
+		let success = false;
+		for (const notification of notifications) {
+			const result = await this.send(notification, monitor, monitorStatusResponse, escalationDecision, notificationMessage);
+			if (result) success = true;
+		}
+		return success;
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -16,6 +16,7 @@ export interface Incident {
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;
 	comment?: string | null;
+	firedEscalations: number[];
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface EscalationRule {
+	delayMinutes: number;
+	notificationType: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +42,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalations: EscalationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -67,6 +67,14 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalations: z
+		.array(
+			z.object({
+				delayMinutes: z.number().min(1),
+				notificationType: z.string().min(1),
+			})
+		)
+		.optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +97,14 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalations: z
+		.array(
+			z.object({
+				delayMinutes: z.number().min(1),
+				notificationType: z.string().min(1),
+			})
+		)
+		.optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- Adds an **escalation rules** system to monitors: users can configure one or more rules that send a follow-up alert through a chosen notification channel after an incident has been active for a specified number of minutes.
- Tracks which escalation thresholds have already fired per incident (`firedEscalations` on the Incident model) to prevent duplicate notifications.
- Adds **Step 8** to the `SuperSimpleQueueHelper` monitoring loop — `checkEscalations()` runs after every check when the monitor is `down` or `breached`.

## Changes

### Server
- `server/src/types/monitor.ts` — added `EscalationRule` interface and `escalations` field on `Monitor`
- `server/src/types/incident.ts` — added `firedEscalations: number[]` field on `Incident`
- `server/src/db/models/Monitor.ts` — added `escalations` subdocument array to Mongoose schema
- `server/src/db/models/Incident.ts` — added `firedEscalations` array field to Mongoose schema
- `server/src/validation/monitorValidation.ts` — added `escalations` to create/edit validation schemas
- `server/src/repositories/incidents/IIncidentsRepository.ts` — added `addFiredEscalation()` to interface
- `server/src/repositories/incidents/MongoIncidentRepository.ts` — implemented `addFiredEscalation()` using `$addToSet`
- `server/src/repositories/monitors/MongoMonitorsRepository.ts` — maps `escalations` when converting documents to entities
- `server/src/service/infrastructure/notificationsService.ts` — added `sendEscalatedNotification()` method
- `server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts` — added Step 8: `checkEscalations()` private method

### Client
- `client/src/Types/Monitor.ts` — added `EscalationRule` interface and `escalations` on `Monitor`
- `client/src/Validation/monitor.ts` — added `escalations` to Zod base schema
- `client/src/Hooks/useMonitorForm.ts` — initializes `escalations` from existing monitor data
- `client/src/Pages/CreateMonitor/index.tsx` — added "Escalated Notifications" `ConfigBox` with dynamic rules UI (delay input + notification type selector + remove button)

### Root
- `package.json` — added convenience `dev` script to start the full stack in one command

## Test plan

- [ ] Create a monitor with no escalation rules — verify existing notification behaviour is unchanged
- [x] Add one escalation rule (e.g. 1 min, email) and force the monitor into a `down` state — confirm the escalation notification fires after the configured delay
- [ ] Verify a second check does NOT re-fire the same escalation (idempotency via `firedEscalations`)
- [ ] Add multiple escalation rules with different delays — confirm each fires independently at the correct time
- [ ] Edit an existing monitor and add/remove escalation rules — confirm changes persist