### PR TITLE
Notification Escalations #1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,57 @@
+# Project Guidelines
+
+## Code Style
+- Use TypeScript conventions used in this repo and preserve existing folder structure and naming patterns.
+- Formatting is mandatory before completing changes:
+  - Client: tabs, double quotes, printWidth 90.
+  - Server: tabs, double quotes, printWidth 150.
+- Keep imports using the existing `@/` path alias when applicable.
+- In the frontend, all user-facing text must be internationalized with `t("...")` (no hardcoded UI copy).
+- Keep pull requests focused and small; avoid bundling unrelated fixes in the same change.
+
+## Architecture
+- Monorepo layout:
+  - `client/`: React + Vite + Redux Toolkit + SWR frontend.
+  - `server/`: Express + TypeScript + Mongoose backend.
+  - `docker/`: environment-specific Docker setups (dev/staging/prod/arm/mono).
+  - `charts/helm/checkmate/`: Helm chart deployment assets.
+- Backend boundaries:
+  - `controllers/` for HTTP handling.
+  - `service/` for business/system/infrastructure logic.
+  - `repositories/` + `db/models/` for data access and schemas.
+  - `routes/v1/`, `middleware/`, `validation/` for API composition.
+- Frontend boundaries:
+  - `Pages/` for route-level views.
+  - `Components/` for reusable UI.
+  - `Features/` for Redux slices.
+  - `Utils/NetworkService.js` as the core API client pattern.
+
+## Build and Test
+- Root:
+  - `npm run prepare`
+- Client (`cd client`):
+  - `npm install`
+  - `npm run dev`
+  - `npm run build`
+  - `npm run lint`
+  - `npm run format` / `npm run format-check`
+- Server (`cd server`):
+  - `npm install`
+  - `npm run dev`
+  - `npm run build`
+  - `npm run test`
+  - `npm run lint` / `npm run lint-fix`
+  - `npm run format` / `npm run format-check`
+
+## Conventions
+- Branch from `develop`, and target `develop` in PRs.
+- Keep API routes under `/api/v1`; preserve existing response/error handling patterns.
+- Local defaults commonly used by contributors:
+  - Client on `http://localhost:5173`
+  - Server on `http://localhost:52345`
+  - MongoDB on `27017`
+- If local setup or env details are needed, use existing docs instead of duplicating guidance:
+  - `../CLAUDE.md`
+  - `../CONTRIBUTING.md`
+  - `../PULLREQUESTS.md`
+  - `../docs/README.md`

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -83,6 +83,7 @@
 		"node_modules/@babel/core": {
 			"version": "7.29.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -353,6 +354,7 @@
 		"node_modules/@emotion/react": {
 			"version": "11.14.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.13.5",
@@ -390,6 +392,7 @@
 		"node_modules/@emotion/styled": {
 			"version": "11.14.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.13.5",
@@ -1159,6 +1162,7 @@
 		"node_modules/@mui/material": {
 			"version": "7.3.7",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.28.4",
 				"@mui/core-downloads-tracker": "^7.3.7",
@@ -1263,6 +1267,7 @@
 		"node_modules/@mui/system": {
 			"version": "7.3.7",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.28.4",
 				"@mui/private-theming": "^7.3.7",
@@ -2303,6 +2308,7 @@
 			"version": "24.5.2",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.12.0"
 			}
@@ -2318,6 +2324,7 @@
 		"node_modules/@types/react": {
 			"version": "18.3.27",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -2439,6 +2446,7 @@
 			"version": "8.15.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2763,6 +2771,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -3194,7 +3203,8 @@
 		},
 		"node_modules/dayjs": {
 			"version": "1.11.13",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/debug": {
 			"version": "4.4.3",
@@ -3576,6 +3586,7 @@
 			"version": "8.57.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -4320,6 +4331,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.27.6"
 			},
@@ -5103,6 +5115,7 @@
 			"resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.19.0.tgz",
 			"integrity": "sha512-REhYUN8gNP3HlcIZS6QU2uy8iovl31cXsrNDkCcqWSQbCkcpdYLczqDz5PVIwNH42UQNyvukjes/RoHPDrOUmQ==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"@mapbox/geojson-rewind": "^0.5.2",
 				"@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -5750,6 +5763,7 @@
 		"node_modules/react-dom": {
 			"version": "18.3.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -5761,6 +5775,7 @@
 		"node_modules/react-hook-form": {
 			"version": "7.71.1",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18.0.0"
 			},
@@ -5960,7 +5975,8 @@
 		},
 		"node_modules/redux": {
 			"version": "5.0.1",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/redux-persist": {
 			"version": "6.0.0",
@@ -6110,6 +6126,7 @@
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
 			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -6898,6 +6915,7 @@
 			"version": "5.9.3",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -7033,6 +7051,7 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
 			"integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",

--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -14,6 +14,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	notifications: data?.notifications || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
+	escalationRules: data?.escalationRules || [],
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,
 	geoCheckLocations: data?.geoCheckLocations || [],
 	geoCheckInterval: data?.geoCheckInterval || 300000,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useEffect } from "react";
 import { logger } from "@/Utils/logger";
 import { useParams, useLocation, useNavigate } from "react-router";
-import { useForm, Controller } from "react-hook-form";
+import { useForm, Controller, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTheme } from "@mui/material";
 import Stack from "@mui/material/Stack";
@@ -203,6 +203,14 @@ const CreateMonitorPage = () => {
 		defaultValues: defaults,
 	});
 	const { control, watch, handleSubmit, clearErrors } = form;
+	const {
+		fields: escalationFields,
+		append: appendEscalationRule,
+		remove: removeEscalationRule,
+	} = useFieldArray({
+		control,
+		name: "escalationRules",
+	});
 
 	useEffect(() => {
 		form.reset(defaults);
@@ -220,6 +228,11 @@ const CreateMonitorPage = () => {
 	const generalSettingsConfig = useMemo(
 		() => getGeneralSettingsConfig(watchedType, t),
 		[watchedType, t]
+	);
+
+	const notificationOptions = useMemo(
+		() => (notifications ?? []).map((notification) => ({ ...notification, name: notification.notificationName })),
+		[notifications]
 	);
 
 	const { post, loading: isCreating } = usePost<MonitorFormData, Monitor>();
@@ -705,11 +718,6 @@ const CreateMonitorPage = () => {
 						name="notifications"
 						control={control}
 						render={({ field }) => {
-							// Map notifications to have 'name' property for Autocomplete
-							const notificationOptions = (notifications ?? []).map((n) => ({
-								...n,
-								name: n.notificationName,
-							}));
 							const selectedNotifications = notificationOptions.filter((n) =>
 								(field.value ?? []).includes(n.id)
 							);
@@ -762,6 +770,84 @@ const CreateMonitorPage = () => {
 							);
 						}}
 					/>
+				}
+			/>
+
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalations.title")}
+				subtitle={t("pages.createMonitor.form.escalations.description")}
+				rightContent={
+					<Stack spacing={theme.spacing(LAYOUT.MD)}>
+						{escalationFields.map((rule, index) => (
+							<Stack
+								key={rule.id}
+								direction={{ xs: "column", md: "row" }}
+								spacing={theme.spacing(LAYOUT.MD)}
+								alignItems={{ xs: "stretch", md: "center" }}
+							>
+								<Controller
+									name={`escalationRules.${index}.delayMinutes` as const}
+									control={control}
+									render={({ field, fieldState }) => (
+										<TextField
+											{...field}
+											value={field.value ?? 0}
+											onChange={(e) => {
+												const val = e.target.value;
+												const parsedValue = val === "" ? 0 : Number(val);
+												field.onChange(Number.isNaN(parsedValue) ? 0 : Math.max(0, parsedValue));
+											}}
+											type="number"
+											inputProps={{ min: 0 }}
+											fieldLabel={t("pages.createMonitor.form.escalations.option.delay.label")}
+											placeholder={t("pages.createMonitor.form.escalations.option.delay.placeholder")}
+											error={!!fieldState.error}
+											helperText={fieldState.error?.message ?? ""}
+											fullWidth
+										/>
+									)}
+								/>
+								<Controller
+									name={`escalationRules.${index}.channelId` as const}
+									control={control}
+									render={({ field, fieldState }) => (
+										<Select
+											{...field}
+											value={field.value ?? ""}
+											fieldLabel={t("pages.createMonitor.form.escalations.option.channel.label")}
+											error={!!fieldState.error}
+										>
+											<MenuItem value="">
+												{t("pages.createMonitor.form.escalations.option.channel.placeholder")}
+											</MenuItem>
+											{notificationOptions.map((notification) => (
+												<MenuItem
+													key={notification.id}
+													value={notification.id}
+												>
+													{notification.notificationName}
+												</MenuItem>
+											))}
+										</Select>
+									)}
+								/>
+								<IconButton
+									size="small"
+									onClick={() => removeEscalationRule(index)}
+									aria-label={t("pages.createMonitor.form.escalations.option.removeRule")}
+								>
+									<Trash2 size={16} />
+								</IconButton>
+							</Stack>
+						))}
+						<Button
+							type="button"
+							variant="outlined"
+							onClick={() => appendEscalationRule({ delayMinutes: 15, channelId: "" })}
+						>
+							{t("pages.createMonitor.form.escalations.option.addRule")}
+						</Button>
+					</Stack>
 				}
 			/>
 

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -231,7 +231,11 @@ const CreateMonitorPage = () => {
 	);
 
 	const notificationOptions = useMemo(
-		() => (notifications ?? []).map((notification) => ({ ...notification, name: notification.notificationName })),
+		() =>
+			(notifications ?? []).map((notification) => ({
+				...notification,
+				name: notification.notificationName,
+			})),
 		[notifications]
 	);
 
@@ -795,12 +799,18 @@ const CreateMonitorPage = () => {
 											onChange={(e) => {
 												const val = e.target.value;
 												const parsedValue = val === "" ? 0 : Number(val);
-												field.onChange(Number.isNaN(parsedValue) ? 0 : Math.max(0, parsedValue));
+												field.onChange(
+													Number.isNaN(parsedValue) ? 0 : Math.max(0, parsedValue)
+												);
 											}}
 											type="number"
 											inputProps={{ min: 0 }}
-											fieldLabel={t("pages.createMonitor.form.escalations.option.delay.label")}
-											placeholder={t("pages.createMonitor.form.escalations.option.delay.placeholder")}
+											fieldLabel={t(
+												"pages.createMonitor.form.escalations.option.delay.label"
+											)}
+											placeholder={t(
+												"pages.createMonitor.form.escalations.option.delay.placeholder"
+											)}
 											error={!!fieldState.error}
 											helperText={fieldState.error?.message ?? ""}
 											fullWidth
@@ -814,11 +824,15 @@ const CreateMonitorPage = () => {
 										<Select
 											{...field}
 											value={field.value ?? ""}
-											fieldLabel={t("pages.createMonitor.form.escalations.option.channel.label")}
+											fieldLabel={t(
+												"pages.createMonitor.form.escalations.option.channel.label"
+											)}
 											error={!!fieldState.error}
 										>
 											<MenuItem value="">
-												{t("pages.createMonitor.form.escalations.option.channel.placeholder")}
+												{t(
+													"pages.createMonitor.form.escalations.option.channel.placeholder"
+												)}
 											</MenuItem>
 											{notificationOptions.map((notification) => (
 												<MenuItem

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface MonitorEscalationRule {
+	delayMinutes: number;
+	channelId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +65,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationRules?: MonitorEscalationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -21,6 +21,12 @@ const baseSchema = z.object({
 		.number({ message: "Threshold percentage is required" })
 		.min(1, "Incident percentage must be at least 1")
 		.max(100, "Incident percentage must be at most 100"),
+	escalationRules: z.array(
+		z.object({
+			delayMinutes: z.number().min(0, "Delay must be at least 0 minutes"),
+			channelId: z.string().min(1, "Notification channel is required"),
+		})
+	),
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -543,6 +543,22 @@
 					"description": "Select the notification channels you want to use",
 					"title": "Notifications"
 				},
+				"escalations": {
+					"title": "Escalation rules",
+					"description": "Trigger additional notification channels if an incident remains active after a delay.",
+					"option": {
+						"delay": {
+							"label": "Delay (minutes)",
+							"placeholder": "15"
+						},
+						"channel": {
+							"label": "Escalation channel",
+							"placeholder": "Select a channel"
+						},
+						"addRule": "Add escalation rule",
+						"removeRule": "Remove escalation rule"
+					}
+				},
 				"type": {
 					"description": "Select the type of check to perform",
 					"optionDockerDescription": "Use Docker to monitor if a container is running.",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -873,6 +873,7 @@
 			"integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.28.6",
 				"@babel/generator": "^7.28.6",
@@ -1502,6 +1503,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -1546,6 +1548,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -4337,6 +4340,7 @@
 			"integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/body-parser": "*",
 				"@types/express-serve-static-core": "^5.0.0",
@@ -4497,6 +4501,7 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
 			"integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -4734,6 +4739,7 @@
 			"integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.56.1",
 				"@typescript-eslint/types": "8.56.1",
@@ -5347,6 +5353,7 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -5925,6 +5932,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.19",
 				"caniuse-lite": "^1.0.30001751",
@@ -6867,6 +6875,7 @@
 			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.1.tgz",
 			"integrity": "sha512-fm4D8ti0dQmFPeF8DXSAA//btEmqCOgAc/9Oa3C1LW94h5usNrJEfrON7b4FkPZgnDEn6OUs5NdxiJZmAtGOpQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssnano-preset-default": "^7.0.9",
 				"lilconfig": "^3.1.3"
@@ -7634,6 +7643,7 @@
 			"integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -7995,6 +8005,7 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
 			"integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
@@ -9639,6 +9650,7 @@
 			"integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/core": "30.2.0",
 				"@jest/types": "30.2.0",
@@ -12509,6 +12521,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -14604,6 +14617,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -14772,6 +14786,7 @@
 			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
@@ -14934,6 +14949,7 @@
 			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -72,6 +72,10 @@ const IncidentSchema = new Schema<IncidentDocument>(
 			type: String,
 			default: null,
 		},
+		triggeredEscalationRuleKeys: {
+			type: [String],
+			default: [],
+		},
 	},
 	{ timestamps: true }
 );

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -1,5 +1,5 @@
 import { Schema, model, Types } from "mongoose";
-import type { Monitor, MonitorMatchMethod, CheckSnapshot } from "@/types/monitor.js";
+import type { Monitor, MonitorMatchMethod, CheckSnapshot, MonitorEscalationRule } from "@/types/monitor.js";
 import { MonitorTypes, MonitorStatuses } from "@/types/monitor.js";
 import type {
 	CheckAudits,
@@ -15,6 +15,7 @@ import type {
 } from "@/types/check.js";
 
 type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Date };
+type MonitorEscalationRuleDocument = Omit<MonitorEscalationRule, "channelId"> & { channelId: Types.ObjectId };
 
 type MonitorDocumentBase = Omit<
 	Monitor,
@@ -23,6 +24,7 @@ type MonitorDocumentBase = Omit<
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
+	escalationRules: MonitorEscalationRuleDocument[];
 	selectedDisks: string[];
 	matchMethod?: MonitorMatchMethod;
 };
@@ -198,6 +200,18 @@ const checkSnapshotSchema = new Schema<CheckSnapshotDocument>(
 	{ _id: false }
 );
 
+const escalationRuleSchema = new Schema<MonitorEscalationRuleDocument>(
+	{
+		delayMinutes: { type: Number, required: true },
+		channelId: {
+			type: Schema.Types.ObjectId,
+			ref: "Notification",
+			required: true,
+		},
+	},
+	{ _id: false }
+);
+
 const MonitorSchema = new Schema<MonitorDocument>(
 	{
 		userId: {
@@ -284,6 +298,10 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalationRules: {
+			type: [escalationRuleSchema],
+			default: [],
+		},
 		secret: {
 			type: String,
 		},

--- a/server/src/repositories/incidents/MongoIncidentRepository.ts
+++ b/server/src/repositories/incidents/MongoIncidentRepository.ts
@@ -60,6 +60,7 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			resolvedBy: doc.resolvedBy ? this.toStringId(doc.resolvedBy) : null,
 			resolvedByEmail: doc.resolvedByEmail ?? null,
 			comment: doc.comment ?? null,
+			triggeredEscalationRuleKeys: doc.triggeredEscalationRuleKeys ?? [],
 			createdAt: this.toDateString(doc.createdAt),
 			updatedAt: this.toDateString(doc.updatedAt),
 		};

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -351,6 +351,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification) => toStringId(notification));
+		const escalationRules = (doc.escalationRules ?? []).map((rule) => ({
+			delayMinutes: rule.delayMinutes,
+			channelId: toStringId(rule.channelId),
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -374,6 +378,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalationRules,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -410,6 +415,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification: unknown) => toStringId(notification));
+		const escalationRules = (doc.escalationRules ?? []).map((rule) => ({
+			delayMinutes: rule.delayMinutes,
+			channelId: toStringId(rule.channelId),
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -433,6 +442,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalationRules,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -12,6 +12,7 @@ import {
 	type IGeoChecksService,
 } from "@/service/index.js";
 import { CHECK_TTL_SENTINEL, type MaintenanceWindow, type StatusChangeResult } from "@/types/index.js";
+import type { Incident, MonitorStatusResponse } from "@/types/index.js";
 import {
 	IMaintenanceWindowsRepository,
 	IMonitorsRepository,
@@ -38,7 +39,7 @@ export interface MonitorActionDecision {
 	shouldResolveIncident: boolean;
 	shouldSendNotification: boolean;
 	incidentReason: "status_down" | "threshold_breach" | null;
-	notificationReason: "status_change" | "threshold_breach" | null;
+	notificationReason: "status_change" | "threshold_breach" | "escalation" | null;
 	thresholdBreaches?: {
 		cpu?: boolean;
 		memory?: boolean;
@@ -168,15 +169,20 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 					});
 				}
 
-				// Step 7. Handle incidents (best effort, don't wait)
-				this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status).catch((error: unknown) => {
-					this.logger.warn({
-						message: `Error handling incident for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
-						service: SERVICE_NAME,
-						method: "getMonitorJob",
-						stack: error instanceof Error ? error.stack : undefined,
+				// Step 7. Handle incidents and escalations (best effort, don't wait)
+				this.incidentService
+					.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status)
+					.then(async () => {
+						await this.processEscalationRules(statusChangeResult.monitor, status);
+					})
+					.catch((error: unknown) => {
+						this.logger.warn({
+							message: `Error handling incident/escalation for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+							service: SERVICE_NAME,
+							method: "getMonitorJob",
+							stack: error instanceof Error ? error.stack : undefined,
+						});
 					});
-				});
 			} catch (error: unknown) {
 				this.logger.warn({
 					message: error instanceof Error ? error.message : "Unknown error",
@@ -187,6 +193,73 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 				throw error;
 			}
 		};
+	};
+
+	private processEscalationRules = async (monitor: Monitor, status: MonitorStatusResponse): Promise<void> => {
+		const escalationRules = monitor.escalationRules ?? [];
+		if (escalationRules.length === 0) {
+			return;
+		}
+
+		if (monitor.status !== "down" && monitor.status !== "breached") {
+			return;
+		}
+
+		const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId);
+		if (!activeIncident) {
+			return;
+		}
+
+		const incidentStartMs = Date.parse(activeIncident.startTime);
+		if (Number.isNaN(incidentStartMs)) {
+			this.logger.warn({
+				message: `Could not parse incident start time for monitor ${monitor.id}`,
+				service: SERVICE_NAME,
+				method: "processEscalationRules",
+			});
+			return;
+		}
+
+		const elapsedMinutes = (Date.now() - incidentStartMs) / (1000 * 60);
+		const triggeredKeys = new Set(activeIncident.triggeredEscalationRuleKeys ?? []);
+
+		for (const rule of escalationRules) {
+			try {
+				if (!rule.channelId) {
+					continue;
+				}
+
+				const ruleKey = `${rule.delayMinutes}:${rule.channelId}`;
+				if (triggeredKeys.has(ruleKey)) {
+					continue;
+				}
+
+				if (elapsedMinutes < rule.delayMinutes) {
+					continue;
+				}
+
+				const sent = await this.notificationsService.handleEscalationNotification(monitor, status, rule.channelId);
+				if (!sent) {
+					continue;
+				}
+
+				triggeredKeys.add(ruleKey);
+				await this.persistTriggeredEscalationRule(activeIncident, triggeredKeys);
+			} catch (error: unknown) {
+				this.logger.warn({
+					message: `Failed escalation rule for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+					service: SERVICE_NAME,
+					method: "processEscalationRules",
+					stack: error instanceof Error ? error.stack : undefined,
+				});
+			}
+		}
+	};
+
+	private persistTriggeredEscalationRule = async (incident: Incident, triggeredKeys: Set<string>): Promise<void> => {
+		await this.incidentsRepository.updateById(incident.id, incident.teamId, {
+			triggeredEscalationRuleKeys: [...triggeredKeys],
+		});
 	};
 
 	getCleanupOrphanedJob = () => {

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -31,7 +31,7 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	): NotificationMessage {
 		const type = this.determineNotificationType(decision, monitor);
 		const severity = this.determineSeverity(type);
-		const content = this.buildContent(type, monitor, monitorStatusResponse);
+		const content = this.buildContent(type, monitor, monitorStatusResponse, decision);
 
 		return {
 			type,
@@ -53,6 +53,10 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	}
 
 	private determineNotificationType(decision: MonitorActionDecision, monitor: Monitor): NotificationType {
+		if (decision.notificationReason === "escalation") {
+			return monitor.status === "breached" ? "threshold_breach" : "monitor_down";
+		}
+
 		// Down status has highest priority (critical)
 		if (monitor.status === "down") {
 			return "monitor_down";
@@ -93,7 +97,16 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		}
 	}
 
-	private buildContent(type: NotificationType, monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): NotificationContent {
+	private buildContent(
+		type: NotificationType,
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		decision: MonitorActionDecision
+	): NotificationContent {
+		if (decision.notificationReason === "escalation") {
+			return this.buildEscalationContent(monitor, monitorStatusResponse);
+		}
+
 		switch (type) {
 			case "monitor_down":
 				return this.buildMonitorDownContent(monitor, monitorStatusResponse);
@@ -106,6 +119,35 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 			default:
 				return this.buildDefaultContent(monitor);
 		}
+	}
+
+	private buildEscalationContent(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): NotificationContent {
+		const isThresholdEscalation = monitor.status === "breached";
+		const title = isThresholdEscalation ? `Escalation: Threshold Exceeded - ${monitor.name}` : `Escalation: Monitor Down - ${monitor.name}`;
+		const summary = isThresholdEscalation
+			? `Escalation alert: monitor "${monitor.name}" remains in a threshold breach state beyond the configured delay.`
+			: `Escalation alert: monitor "${monitor.name}" remains down beyond the configured delay.`;
+		const details = [
+			`URL: ${monitor.url}`,
+			`Status: ${monitor.status}`,
+			`Type: ${monitor.type}`,
+			"Escalation reason: Incident is still active after escalation delay.",
+		];
+
+		if (monitorStatusResponse.code) {
+			details.push(`Response Code: ${monitorStatusResponse.code}`);
+		}
+
+		if (monitorStatusResponse.message) {
+			details.push(`Error: ${monitorStatusResponse.message}`);
+		}
+
+		return {
+			title,
+			summary,
+			details,
+			timestamp: new Date(),
+		};
 	}
 
 	private buildMonitorDownContent(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): NotificationContent {

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -78,17 +78,19 @@ export class EmailProvider implements INotificationProvider {
 	}
 
 	private buildSubject(message: NotificationMessage): string {
+		const escalationPrefix = message.metadata.notificationReason === "escalation" ? "[ESCALATION] " : "";
+
 		switch (message.type) {
 			case "monitor_down":
-				return `Monitor ${message.monitor.name} is down`;
+				return `${escalationPrefix}Monitor ${message.monitor.name} is down`;
 			case "monitor_up":
 				return `Monitor ${message.monitor.name} is back up`;
 			case "threshold_breach":
-				return `Monitor ${message.monitor.name} threshold exceeded`;
+				return `${escalationPrefix}Monitor ${message.monitor.name} threshold exceeded`;
 			case "threshold_resolved":
 				return `Monitor ${message.monitor.name} thresholds resolved`;
 			default:
-				return `Alert: ${message.monitor.name}`;
+				return `${escalationPrefix}Alert: ${message.monitor.name}`;
 		}
 	}
 

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,6 +14,11 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	handleEscalationNotification: (
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		escalationChannelId: string
+	) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -139,6 +144,22 @@ export class NotificationsService implements INotificationsService {
 
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	handleEscalationNotification = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, escalationChannelId: string) => {
+		const escalationChannel = await this.notificationsRepository.findById(escalationChannelId, monitor.teamId);
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+		const escalationDecision: MonitorActionDecision = {
+			shouldCreateIncident: false,
+			shouldResolveIncident: false,
+			shouldSendNotification: true,
+			incidentReason: null,
+			notificationReason: "escalation",
+		};
+		const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, escalationDecision, clientHost);
+
+		return await this.send(escalationChannel, monitor, monitorStatusResponse, escalationDecision, notificationMessage);
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,11 +14,7 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
-	handleEscalationNotification: (
-		monitor: Monitor,
-		monitorStatusResponse: MonitorStatusResponse,
-		escalationChannelId: string
-	) => Promise<boolean>;
+	handleEscalationNotification: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, escalationChannelId: string) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -16,6 +16,7 @@ export interface Incident {
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;
 	comment?: string | null;
+	triggeredEscalationRuleKeys?: string[];
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface MonitorEscalationRule {
+	delayMinutes: number;
+	channelId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +42,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationRules?: MonitorEscalationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -49,6 +49,11 @@ export const getCertificateParamValidation = z.object({
 	monitorId: z.string().min(1, "Monitor ID is required"),
 });
 
+const escalationRuleSchema = z.object({
+	delayMinutes: z.number().min(0),
+	channelId: z.string().min(1),
+});
+
 export const createMonitorBodyValidation = z.object({
 	_id: z.string().optional(),
 	name: z.string().min(1, "Name is required"),
@@ -67,6 +72,7 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalationRules: z.array(escalationRuleSchema).optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +95,7 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalationRules: z.array(escalationRuleSchema).optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),
@@ -144,6 +151,7 @@ const importedMonitorSchema = z.object({
 	interval: z.number().default(60000),
 	uptimePercentage: z.number().optional(),
 	notifications: z.array(z.string()).default([]),
+	escalationRules: z.array(escalationRuleSchema).default([]),
 	secret: z.string().optional(),
 	cpuAlertThreshold: z.number().default(100),
 	cpuAlertCounter: z.number().default(5),


### PR DESCRIPTION
## Describe your changes

Implemented an end-to-end notification escalation system that allows users to define secondary alert rules based on incident duration.

* Database & Persistence: Updated the Monitor model to store escalationRules and the Incident model to track triggeredEscalationRuleKeys for deduplication.

* Backend Logic: Modified the SuperSimpleQueueHelper to calculate elapsed incident time. If the time exceeds a user-defined threshold, the system triggers a targeted notification via the NotificationsService.

* Notification Overhaul: Added a specific escalation notification reason to the NotificationMessageBuilder. Escalation emails now feature distinct subject lines (prepended with [ESCALATION]) and unique body content to distinguish them from standard "Down" alerts.

* Frontend UI: Added a dynamic "Escalation Rules" section to the Monitor configuration page using Material UI. Implemented input clamping to prevent negative delay values.

Fixes #1 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

