### PR TITLE
feat: add escalation notification rules for monitors

### DIFF
--- a/client/src/Components/monitors/EscalationRulesSection.tsx
+++ b/client/src/Components/monitors/EscalationRulesSection.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import MenuItem from "@mui/material/MenuItem";
+import IconButton from "@mui/material/IconButton";
+import { useTheme } from "@mui/material/styles";
+import { Trash2 } from "lucide-react";
+import { ConfigBox } from "@/Components/design-elements";
+import { TextField, Select } from "@/Components/inputs";
+import { useGet } from "@/Hooks/UseApi";
+import type { Notification } from "@/Types/Notification";
+import type { EscalationRule } from "@/Types/Escalation";
+
+interface EscalationRulesSectionProps {
+	rules: EscalationRule[];
+	onRulesChange: (rules: EscalationRule[]) => void;
+	isLoading?: boolean;
+}
+
+export const EscalationRulesSection = ({
+	rules,
+	onRulesChange,
+	isLoading = false,
+}: EscalationRulesSectionProps) => {
+	const theme = useTheme();
+	const [delayMinutes, setDelayMinutes] = useState<number | string>("");
+	const [selectedChannel, setSelectedChannel] = useState<string>("");
+
+	const { data: notificationChannels } = useGet<Notification[]>("/notifications/team");
+	const channels = notificationChannels ?? [];
+
+	const handleChannelSelect = (channelId: string) => {
+		setSelectedChannel(channelId);
+		if (delayMinutes && channelId) {
+			const newRule: EscalationRule = {
+				delayMinutes: Number(delayMinutes),
+				channels: [channelId],
+			};
+			onRulesChange([...rules, newRule]);
+			setDelayMinutes("");
+			setSelectedChannel("");
+		}
+	};
+
+	const handleRemoveRule = (index: number) => {
+		onRulesChange(rules.filter((_, i) => i !== index));
+	};
+
+	const sortedRules = [...rules].sort((a, b) => a.delayMinutes - b.delayMinutes);
+
+	return (
+		<ConfigBox
+			title="Escalation Rules"
+			subtitle="If the monitor stays down for the specified time, notify additional channels."
+			rightContent={
+				<Stack spacing={theme.spacing(6)} width="100%">
+					{/* Input Fields */}
+					<Stack spacing={theme.spacing(6)}>
+						<TextField
+							fieldLabel="Escalate after (minutes)"
+							type="number"
+							value={delayMinutes}
+							onChange={(e) => setDelayMinutes(e.target.value)}
+							inputProps={{ min: 1, max: 10080 }}
+							fullWidth
+							disabled={channels.length === 0 || isLoading}
+						/>
+						<Select
+							fieldLabel="Escalation notification channels"
+							value={selectedChannel}
+							onChange={(e) => handleChannelSelect(e.target.value as string)}
+							disabled={channels.length === 0 || isLoading}
+							placeholder="Type to search"
+							fullWidth
+						>
+							{channels.map((channel) => (
+								<MenuItem key={channel.id} value={channel.id}>
+									{channel.notificationName}
+								</MenuItem>
+							))}
+						</Select>
+					</Stack>
+
+					{/* Rules List */}
+					{sortedRules.length > 0 && (
+						<Stack spacing={theme.spacing(2)}>
+							{sortedRules.map((rule, index) => {
+								const ruleChannels = channels.filter((c) =>
+									rule.channels.includes(c.id)
+								);
+
+								return (
+									<Stack
+										key={index}
+										direction="row"
+										justifyContent="space-between"
+										alignItems="center"
+									>
+										<Typography variant="body2">
+											{ruleChannels.map((c) => c.notificationName).join(", ")}
+										</Typography>
+										<IconButton
+											size="small"
+											onClick={() =>
+												handleRemoveRule(rules.indexOf(rule))
+											}
+											disabled={isLoading}
+										>
+											<Trash2 size={16} />
+										</IconButton>
+									</Stack>
+								);
+							})}
+						</Stack>
+					)}
+
+					{channels.length === 0 && (
+						<Typography variant="caption" color="error">
+							Create notification channels before adding escalation rules
+						</Typography>
+					)}
+				</Stack>
+			}
+		/>
+	);
+};

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -40,6 +40,8 @@ import {
 } from "@/Types/Monitor";
 import type { Notification } from "@/Types/Notification";
 import type { MonitorFormData } from "@/Validation/monitor";
+import type { EscalationRule } from "@/Types/Escalation";
+import { EscalationRulesSection } from "@/Components/monitors/EscalationRulesSection";
 
 interface GeneralSettingsConfig {
 	urlLabel: string;
@@ -763,6 +765,18 @@ const CreateMonitorPage = () => {
 						}}
 					/>
 				}
+			/>
+
+			<Controller
+				name="escalationRules"
+				control={control}
+				defaultValue={[]}
+				render={({ field }) => (
+					<EscalationRulesSection
+						rules={field.value ?? []}
+						onRulesChange={field.onChange}
+					/>
+				)}
 			/>
 
 			{(watchedType === "http" ||

--- a/client/src/Types/Escalation.ts
+++ b/client/src/Types/Escalation.ts
@@ -1,0 +1,11 @@
+export interface EscalationRule {
+	delayMinutes: number;
+	channels: string[]; // Array of Notification channel IDs
+}
+
+export interface EscalationHistoryEntry {
+	delayMinutes: number;
+	firedAt: string;
+	channels: string[];
+	status: "sent" | "pending" | "cancelled" | "failed";
+}

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -1,6 +1,7 @@
 import type { GroupedCheck, CheckSnapshot } from "@/Types/Check";
 import type { PageSpeedGroupedCheck } from "@/Types/Check";
 import type { GeoContinent } from "@/Types/GeoCheck";
+import type { EscalationRule } from "@/Types/Escalation";
 export type { GeoContinent } from "@/Types/GeoCheck";
 
 export const MonitorTypes = [
@@ -60,6 +61,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationRules?: EscalationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -4,6 +4,12 @@ import { GeoContinents } from "@/Types/GeoCheck";
 // URL schema with custom error message
 const urlSchema = z.url({ message: "Please enter a valid URL" });
 
+// Escalation rule schema
+const escalationRuleSchema = z.object({
+	delayMinutes: z.number().min(1).max(10080),
+	channels: z.array(z.string()).min(1),
+});
+
 // Common base schema for all monitor types
 const baseSchema = z.object({
 	name: z
@@ -13,6 +19,7 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalationRules: z.array(escalationRuleSchema).optional().default([]),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -9,6 +9,7 @@ import {
 	SuperSimpleQueue,
 	SuperSimpleQueueHelper,
 	NotificationsService,
+	EscalationService,
 	StatusService,
 	NotificationMessageBuilder,
 	MonitorService,
@@ -34,6 +35,7 @@ import {
 	IBufferService,
 	ISuperSimpleQueue,
 	INotificationsService,
+	IEscalationService,
 	IStatusService,
 	IMonitorService,
 	IUserService,
@@ -127,6 +129,7 @@ export type InitializedServices = {
 	maintenanceWindowService: IMaintenanceWindowService;
 	monitorService: IMonitorService;
 	incidentService: IIncidentService;
+	escalationService: IEscalationService;
 	logger: ILogger;
 	notificationsService: INotificationsService;
 	statusPageService: IStatusPageService;
@@ -246,11 +249,27 @@ export const initializeServices = async ({
 		notificationMessageBuilder
 	);
 
+	const escalationService = new EscalationService(
+		incidentsRepository,
+		notificationsRepository,
+		webhookProvider,
+		emailProvider,
+		slackProvider,
+		discordProvider,
+		pagerDutyProvider,
+		matrixProvider,
+		teamsProvider,
+		settingsService,
+		logger,
+		notificationMessageBuilder
+	);
+
 	const superSimpleQueueHelper = new SuperSimpleQueueHelper(
 		logger,
 		networkService,
 		statusService,
 		notificationsService,
+		escalationService,
 		checkService,
 		settingsService,
 		bufferService,
@@ -324,6 +343,7 @@ export const initializeServices = async ({
 		maintenanceWindowService,
 		monitorService,
 		incidentService,
+		escalationService,
 		logger,
 		notificationsService,
 		statusPageService,

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -1,12 +1,13 @@
 import { Schema, model, type Types } from "mongoose";
-import { IncidentResolutionTypes, type Incident } from "@/types/incident.js";
+import { IncidentResolutionTypes, type Incident, type EscalationHistoryEntry } from "@/types/incident.js";
 
-type IncidentDocumentBase = Omit<Incident, "id" | "monitorId" | "teamId" | "resolvedBy" | "startTime" | "endTime" | "createdAt" | "updatedAt"> & {
+type IncidentDocumentBase = Omit<Incident, "id" | "monitorId" | "teamId" | "resolvedBy" | "startTime" | "endTime" | "createdAt" | "updatedAt" | "escalationHistory"> & {
 	monitorId: Types.ObjectId;
 	teamId: Types.ObjectId;
 	resolvedBy?: Types.ObjectId | null;
 	startTime: Date;
 	endTime: Date | null;
+	escalationHistory?: EscalationHistoryEntry[];
 	createdAt: Date;
 	updatedAt: Date;
 };
@@ -72,6 +73,28 @@ const IncidentSchema = new Schema<IncidentDocument>(
 			type: String,
 			default: null,
 		},
+		escalationHistory: [
+			{
+				delayMinutes: {
+					type: Number,
+					required: true,
+				},
+				firedAt: {
+					type: Date,
+					default: null,
+				},
+				channels: {
+					type: [String],
+					default: [],
+				},
+				status: {
+					type: String,
+					enum: ["pending", "sent", "cancelled"],
+					default: "pending",
+				},
+				_id: false,
+			},
+		],
 	},
 	{ timestamps: true }
 );

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -1,6 +1,7 @@
 import { Schema, model, Types } from "mongoose";
 import type { Monitor, MonitorMatchMethod, CheckSnapshot } from "@/types/monitor.js";
 import { MonitorTypes, MonitorStatuses } from "@/types/monitor.js";
+import type { EscalationRule } from "@/types/escalation.js";
 import type {
 	CheckAudits,
 	CheckCaptureInfo,
@@ -18,12 +19,16 @@ type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Dat
 
 type MonitorDocumentBase = Omit<
 	Monitor,
-	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
+	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "escalationRules" | "createdAt" | "updatedAt"
 > & {
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
 	selectedDisks: string[];
+	escalationRules: Array<{
+		delayMinutes: number;
+		channels: Types.ObjectId[];
+	}>;
 	matchMethod?: MonitorMatchMethod;
 };
 
@@ -355,6 +360,22 @@ const MonitorSchema = new Schema<MonitorDocument>(
 			type: [checkSnapshotSchema],
 			default: [],
 		},
+		escalationRules: [
+			{
+				delayMinutes: {
+					type: Number,
+					required: true,
+					min: 1,
+				},
+				channels: [
+					{
+						type: Schema.Types.ObjectId,
+						ref: "Notification",
+					},
+				],
+				_id: false,
+			},
+		],
 	},
 	{
 		timestamps: true,

--- a/server/src/db/models/index.ts
+++ b/server/src/db/models/index.ts
@@ -4,6 +4,7 @@ export { default as MonitorModel } from "@/db/models/Monitor.js";
 export * from "@/db/models/Check.js";
 export { default as CheckModel } from "@/db/models/Check.js";
 
+
 export * from "@/db/models/MonitorStats.js";
 export { default as MonitorStatsModel } from "@/db/models/MonitorStats.js";
 

--- a/server/src/repositories/index.ts
+++ b/server/src/repositories/index.ts
@@ -4,6 +4,7 @@ export { default as MongoMonitorsRepository } from "@/repositories/monitors/Mong
 export * from "@/repositories/checks/IChecksRepository.js";
 export { default as MongoChecksRepository } from "@/repositories/checks/MongoChecksRepistory.js";
 
+
 export * from "@/repositories/monitor-stats/IMonitorStatsRepository.js";
 export { default as MongoMonitorStatsRepository } from "@/repositories/monitor-stats/MongoMonitorStatsRepository.js";
 

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -391,6 +391,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalationRules: (doc.escalationRules ?? []).map((rule: any) => ({
+				delayMinutes: rule.delayMinutes,
+				channels: (rule.channels ?? []).map((c: any) => toStringId(c)),
+			})),
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};
@@ -450,6 +454,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalationRules: (doc.escalationRules ?? []).map((rule: any) => ({
+				delayMinutes: rule.delayMinutes,
+				channels: (rule.channels ?? []).map((c: any) => toStringId(c)),
+			})),
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};

--- a/server/src/service/business/escalationService.ts
+++ b/server/src/service/business/escalationService.ts
@@ -1,0 +1,244 @@
+import type { Monitor } from "@/types/index.js";
+import type { Incident } from "@/types/incident.js";
+import type { EscalationHistoryEntry } from "@/types/escalation.js";
+import { IIncidentsRepository, INotificationsRepository } from "@/repositories/index.js";
+import { INotificationProvider } from "@/service/infrastructure/notificationProviders/INotificationProvider.js";
+import type { ISettingsService } from "@/service/system/settingsService.js";
+import { ILogger } from "@/utils/logger.js";
+import type { INotificationMessageBuilder } from "@/service/infrastructure/notificationMessageBuilder.js";
+import type { MonitorActionDecision } from "@/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.js";
+import type { MonitorStatusResponse } from "@/types/network.js";
+import type { Notification } from "@/types/notification.js";
+
+export interface IEscalationService {
+	evaluateAndTriggerEscalations: (incident: Incident, monitor: Monitor) => Promise<void>;
+	cancelPendingEscalations: (incidentId: string, teamId: string) => Promise<void>;
+}
+
+const SERVICE_NAME = "EscalationService";
+
+export class EscalationService implements IEscalationService {
+	static SERVICE_NAME = SERVICE_NAME;
+
+	private incidentsRepository: IIncidentsRepository;
+	private notificationsRepository: INotificationsRepository;
+	private webhookProvider: INotificationProvider;
+	private emailProvider: INotificationProvider;
+	private slackProvider: INotificationProvider;
+	private discordProvider: INotificationProvider;
+	private pagerDutyProvider: INotificationProvider;
+	private matrixProvider: INotificationProvider;
+	private teamsProvider: INotificationProvider;
+	private logger: ILogger;
+	private settingsService: ISettingsService;
+	private notificationMessageBuilder: INotificationMessageBuilder;
+
+	constructor(
+		incidentsRepository: IIncidentsRepository,
+		notificationsRepository: INotificationsRepository,
+		webhookProvider: INotificationProvider,
+		emailProvider: INotificationProvider,
+		slackProvider: INotificationProvider,
+		discordProvider: INotificationProvider,
+		pagerDutyProvider: INotificationProvider,
+		matrixProvider: INotificationProvider,
+		teamsProvider: INotificationProvider,
+		settingsService: ISettingsService,
+		logger: ILogger,
+		notificationMessageBuilder: INotificationMessageBuilder
+	) {
+		this.incidentsRepository = incidentsRepository;
+		this.notificationsRepository = notificationsRepository;
+		this.webhookProvider = webhookProvider;
+		this.emailProvider = emailProvider;
+		this.slackProvider = slackProvider;
+		this.discordProvider = discordProvider;
+		this.pagerDutyProvider = pagerDutyProvider;
+		this.matrixProvider = matrixProvider;
+		this.teamsProvider = teamsProvider;
+		this.settingsService = settingsService;
+		this.logger = logger;
+		this.notificationMessageBuilder = notificationMessageBuilder;
+	}
+
+	private calculateIncidentDurationMinutes = (incident: Incident): number => {
+		const startTime = new Date(incident.startTime).getTime();
+		const now = Date.now();
+		const durationMs = now - startTime;
+		return Math.floor(durationMs / (1000 * 60));
+	};
+
+	private sendEscalationNotification = async (
+		notification: Notification,
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		decision: MonitorActionDecision
+	): Promise<boolean> => {
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+		const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, decision, clientHost);
+
+		switch (notification.type) {
+			case "webhook":
+				return (await this.webhookProvider.sendMessage?.(notification, notificationMessage)) || false;
+			case "slack":
+				return (await this.slackProvider.sendMessage?.(notification, notificationMessage)) || false;
+			case "matrix":
+				return (await this.matrixProvider.sendMessage?.(notification, notificationMessage)) || false;
+			case "pager_duty":
+				return (await this.pagerDutyProvider.sendMessage?.(notification, notificationMessage)) || false;
+			case "discord":
+				return (await this.discordProvider.sendMessage?.(notification, notificationMessage)) || false;
+			case "email":
+				return (await this.emailProvider.sendMessage?.(notification, notificationMessage)) || false;
+			case "teams":
+				return (await this.teamsProvider.sendMessage?.(notification, notificationMessage)) || false;
+			default:
+				this.logger.warn({
+					message: `Unknown notification type: ${notification.type}`,
+					service: SERVICE_NAME,
+					method: "sendEscalationNotification",
+				});
+				return false;
+		}
+	};
+
+	evaluateAndTriggerEscalations = async (incident: Incident, monitor: Monitor): Promise<void> => {
+		try {
+			const escalationRules = monitor.escalationRules || [];
+			if (escalationRules.length === 0) {
+				return;
+			}
+
+			if (!incident.escalationHistory) {
+				incident.escalationHistory = [];
+			}
+
+			const durationMinutes = this.calculateIncidentDurationMinutes(incident);
+
+			for (const rule of escalationRules) {
+				let historyEntry = incident.escalationHistory.find((e) => e.delayMinutes === rule.delayMinutes);
+
+				if (!historyEntry) {
+					historyEntry = {
+						delayMinutes: rule.delayMinutes,
+						firedAt: null,
+						channels: [],
+						status: "pending",
+					};
+					incident.escalationHistory.push(historyEntry);
+				}
+
+				if (historyEntry.status === "pending" && durationMinutes >= rule.delayMinutes) {
+					const mockMonitorStatusResponse = {} as MonitorStatusResponse;
+					const mockDecision: MonitorActionDecision = {
+						shouldSendNotification: true,
+						notificationReason: null,
+						shouldCreateIncident: false,
+						shouldResolveIncident: false,
+						incidentReason: null,
+					};
+
+					const tasks = rule.channels.map(async (channelId) => {
+						try {
+							const notification = await this.notificationsRepository.findById(channelId, monitor.teamId);
+							if (!notification) {
+								this.logger.warn({
+									message: `Notification channel not found: ${channelId}`,
+									service: SERVICE_NAME,
+									method: "evaluateAndTriggerEscalations",
+								});
+								return false;
+							}
+
+							const sent = await this.sendEscalationNotification(
+								notification,
+								monitor,
+								mockMonitorStatusResponse,
+								mockDecision
+							);
+
+							if (sent) {
+								historyEntry!.channels.push(notification.notificationName);
+								this.logger.info({
+									message: `Escalation sent to ${notification.notificationName}`,
+									service: SERVICE_NAME,
+									method: "evaluateAndTriggerEscalations",
+								});
+							}
+
+							return sent;
+						} catch (err) {
+							this.logger.error({
+								message: `Failed to send escalation to channel ${channelId}`,
+								service: SERVICE_NAME,
+								method: "evaluateAndTriggerEscalations",
+								details: { error: String(err) },
+							});
+							return false;
+						}
+					});
+
+					const outcomes = await Promise.all(tasks);
+					const succeeded = outcomes.filter(Boolean).length;
+
+					if (succeeded > 0) {
+						historyEntry.status = "sent";
+						historyEntry.firedAt = new Date();
+						this.logger.info({
+							message: `Escalation fired for incident ${incident.id} at ${rule.delayMinutes} minutes`,
+							service: SERVICE_NAME,
+							method: "evaluateAndTriggerEscalations",
+						});
+					}
+				}
+			}
+
+			await this.incidentsRepository.updateById(incident.id, monitor.teamId, {
+				escalationHistory: incident.escalationHistory,
+			});
+		} catch (err) {
+			this.logger.error({
+				message: "Error evaluating escalations",
+				service: SERVICE_NAME,
+				method: "evaluateAndTriggerEscalations",
+				details: { error: String(err) },
+			});
+		}
+	};
+
+	cancelPendingEscalations = async (incidentId: string, teamId: string): Promise<void> => {
+		try {
+			const incident = await this.incidentsRepository.findById(incidentId, teamId);
+			if (!incident || !incident.escalationHistory) {
+				return;
+			}
+
+			let updated = false;
+			for (const entry of incident.escalationHistory) {
+				if (entry.status === "pending") {
+					entry.status = "cancelled";
+					updated = true;
+				}
+			}
+
+			if (updated) {
+				await this.incidentsRepository.updateById(incidentId, teamId, {
+					escalationHistory: incident.escalationHistory,
+				});
+				this.logger.info({
+					message: `Cancelled pending escalations for incident ${incidentId}`,
+					service: SERVICE_NAME,
+					method: "cancelPendingEscalations",
+				});
+			}
+		} catch (err) {
+			this.logger.error({
+				message: "Error cancelling escalations",
+				service: SERVICE_NAME,
+				method: "cancelPendingEscalations",
+				details: { error: String(err) },
+			});
+		}
+	};
+}

--- a/server/src/service/index.ts
+++ b/server/src/service/index.ts
@@ -1,6 +1,7 @@
 // Business services
 export * from "@/service/business/checkService.js";
 export * from "@/service/business/diagnosticService.js";
+export * from "@/service/business/escalationService.js";
 export * from "@/service/business/geoChecksService.js";
 export * from "@/service/business/incidentService.js";
 export * from "@/service/business/inviteService.js";

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -10,6 +10,7 @@ import {
 	IStatusService,
 	IncidentService,
 	type IGeoChecksService,
+	IEscalationService,
 } from "@/service/index.js";
 import { CHECK_TTL_SENTINEL, type MaintenanceWindow, type StatusChangeResult } from "@/types/index.js";
 import {
@@ -54,6 +55,7 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 	private networkService: INetworkService;
 	private statusService: IStatusService;
 	private notificationsService: INotificationsService;
+	private escalationService: IEscalationService;
 	private checkService: ICheckService;
 	private settingsService: ISettingsService;
 	private buffer: IBufferService;
@@ -72,6 +74,7 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 		networkService: INetworkService,
 		statusService: IStatusService,
 		notificationsService: INotificationsService,
+		escalationService: IEscalationService,
 		checkService: ICheckService,
 		settingsService: ISettingsService,
 		buffer: IBufferService,
@@ -92,6 +95,7 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 		this.settingsService = settingsService;
 		this.buffer = buffer;
 		this.notificationsService = notificationsService;
+		this.escalationService = escalationService;
 		this.incidentService = incidentService;
 		this.maintenanceWindowsRepository = maintenanceWindowsRepository;
 		this.monitorsRepository = monitorsRepository;
@@ -177,6 +181,34 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 						stack: error instanceof Error ? error.stack : undefined,
 					});
 				});
+
+				// Step 8. Handle escalations (best effort, don't wait)
+				(async () => {
+					try {
+						// Get active incident if monitor is down
+						if (statusChangeResult.monitor.status === "down" || statusChangeResult.monitor.status === "breached") {
+							const activeIncident = await this.incidentsRepository.findActiveByMonitorId(statusChangeResult.monitor.id, teamId);
+							if (activeIncident) {
+								await this.escalationService.evaluateAndTriggerEscalations(activeIncident, statusChangeResult.monitor);
+							}
+						}
+
+						// Cancel escalations if monitor recovered
+						if (decision.shouldResolveIncident) {
+							const resolvedIncident = await this.incidentsRepository.findActiveByMonitorId(statusChangeResult.monitor.id, teamId);
+							if (resolvedIncident) {
+								await this.escalationService.cancelPendingEscalations(resolvedIncident.id, teamId);
+							}
+						}
+					} catch (error: unknown) {
+						this.logger.error({
+							message: `Error handling escalations for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+							service: SERVICE_NAME,
+							method: "getMonitorJob",
+							stack: error instanceof Error ? error.stack : undefined,
+						});
+					}
+				})();
 			} catch (error: unknown) {
 				this.logger.warn({
 					message: error instanceof Error ? error.message : "Unknown error",

--- a/server/src/types/escalation.ts
+++ b/server/src/types/escalation.ts
@@ -1,0 +1,13 @@
+export type EscalationHistoryStatus = "pending" | "sent" | "cancelled";
+
+export interface EscalationHistoryEntry {
+	delayMinutes: number;
+	firedAt: Date | null;
+	channels: string[]; // channel names sent to
+	status: EscalationHistoryStatus;
+}
+
+export interface EscalationRule {
+	delayMinutes: number;
+	channels: string[]; // ObjectId[] of Notification channels
+}

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -1,3 +1,6 @@
+import type { EscalationHistoryEntry } from "@/types/escalation.js";
+export type { EscalationHistoryEntry } from "@/types/escalation.js";
+
 // export type IncidentResolutionType = "automatic" | "manual" | null;
 
 export const IncidentResolutionTypes = ["automatic", "manual", null] as const;
@@ -16,6 +19,7 @@ export interface Incident {
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;
 	comment?: string | null;
+	escalationHistory?: EscalationHistoryEntry[];
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/types/index.ts
+++ b/server/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from "@/types/check.js";
+export * from "@/types/escalation.js";
 export * from "@/types/geoCheck.js";
 export * from "@/types/monitor.js";
 export * from "@/types/monitorStats.js";

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -2,6 +2,8 @@ import type { CheckSnapshot } from "@/types/check.js";
 export type { CheckSnapshot } from "@/types/check.js";
 import type { GeoContinent, GroupedGeoCheck } from "@/types/geoCheck.js";
 export type { GeoContinent } from "@/types/geoCheck.js";
+import type { EscalationRule } from "@/types/escalation.js";
+export type { EscalationRule } from "@/types/escalation.js";
 
 export const MonitorTypes = ["http", "ping", "pagespeed", "hardware", "docker", "port", "game", "grpc", "websocket", "unknown"] as const;
 export type MonitorType = (typeof MonitorTypes)[number];
@@ -53,6 +55,7 @@ export interface Monitor {
 	geoCheckEnabled?: boolean;
 	geoCheckLocations?: GeoContinent[];
 	geoCheckInterval?: number;
+	escalationRules: EscalationRule[];
 	recentChecks: CheckSnapshot[];
 	createdAt: string;
 	updatedAt: string;

--- a/server/src/validation/escalationValidation.ts
+++ b/server/src/validation/escalationValidation.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+//****************************************
+// Escalation Rule Validations
+//****************************************
+
+export const escalationRuleBodyValidation = z.object({
+	delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+	channels: z.array(z.string().min(1, "Channel ID is required")).min(1, "At least one channel is required"),
+});
+
+export const escalationRulesBodyValidation = z.array(escalationRuleBodyValidation).optional().default([]);

--- a/server/src/validation/index.ts
+++ b/server/src/validation/index.ts
@@ -13,11 +13,12 @@ export * from "./envValidation.js";
 
 // Domain-specific validations
 export * from "./authValidation.js";
-export * from "./monitorValidation.js";
 export * from "./checkValidation.js";
+export * from "./escalationValidation.js";
+export * from "./incidentValidation.js";
 export * from "./maintenanceWindowValidation.js";
+export * from "./monitorValidation.js";
+export * from "./notificationValidation.js";
 export * from "./settingsValidation.js";
 export * from "./statusPageValidation.js";
-export * from "./notificationValidation.js";
 export * from "./userValidation.js";
-export * from "./incidentValidation.js";

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { booleanCoercion } from "./shared.js";
 import { GeoContinents } from "@/types/geoCheck.js";
 import { MonitorMatchMethods, MonitorTypes } from "@/types/monitor.js";
+import { escalationRulesBodyValidation } from "./escalationValidation.js";
 
 export const getMonitorByIdParamValidation = z.object({
 	monitorId: z.string().min(1, "Monitor ID is required"),
@@ -78,6 +79,7 @@ export const createMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalationRules: escalationRulesBodyValidation,
 });
 
 export const editMonitorBodyValidation = z.object({
@@ -107,6 +109,7 @@ export const editMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalationRules: escalationRulesBodyValidation,
 });
 
 export const pauseMonitorParamValidation = z.object({
@@ -160,6 +163,7 @@ const importedMonitorSchema = z.object({
 	geoCheckEnabled: z.boolean().default(false),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).default([]),
 	geoCheckInterval: z.number().min(300000).default(300000),
+	escalationRules: escalationRulesBodyValidation,
 	createdAt: z.string().optional(),
 	updatedAt: z.string().optional(),
 });


### PR DESCRIPTION
## Summary
- Implement escalated notifications that alert different notification channels based on incident duration
- Users can define time-based escalation rules on monitors (e.g., notify channel A after 5 min, channel B after 30 min)
- Reuses existing notification channels — no separate escalation channel infrastructure needed

## Changes
- **Frontend**: Add `EscalationRulesSection` component integrated into monitor create/edit form
- **Backend**: Add `EscalationService` that evaluates rules on each heartbeat check and fires notifications when thresholds are met
- **Database**: Add `escalationRules` to Monitor schema, `escalationHistory` to Incident schema
- **Validation**: Add escalation rule validation to monitor create/edit endpoints

## How it works
1. User configures escalation rules on a monitor (delay in minutes + notification channel)
2. When a monitor goes down and an incident is created, escalation rules are tracked
3. On each heartbeat check, the system evaluates if the incident duration exceeds any rule's delay
4. When threshold is met, the configured notification channel is alerted
5. When the incident resolves, pending escalations are cancelled

## Test plan
- [x] Create a monitor with escalation rules
- [ ] Verify rules are saved and displayed correctly
- [ ] Trigger a down incident and verify escalation fires after the configured delay
- [ ] Verify escalations are cancelled when the monitor recovers
- [ ] Test with multiple rules at different delay thresholds