### PR TITLE
Added escalation UI and partial implementation

### DIFF
--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -764,6 +764,72 @@ const CreateMonitorPage = () => {
 					/>
 				}
 			/>
+{/* ESCALATION */}
+		<ConfigBox
+			title="Escalation Settings"
+			subtitle="Optional alerts if issue continues"
+			rightContent={
+				<Stack spacing={theme.spacing(LAYOUT.MD)}>
+					<Controller
+						name="escalationEnabled"
+						control={control}
+						render={({ field }) => (
+							<Stack direction="row" alignItems="center" spacing={1}>
+								<Switch
+									checked={field.value || false}
+									onChange={(e) => field.onChange(e.target.checked)}
+								/>
+								<Typography>Turn on escalation</Typography>
+							</Stack>
+						)}
+					/>
+
+					<Controller
+						name="escalationMinutes"
+						control={control}
+						render={({ field }) => (
+							<TextField
+								{...field}
+								type="number"
+								fieldLabel="Wait time (minutes)"
+								fullWidth
+							/>
+						)}
+					/>
+
+					<Controller
+						name="escalationNotifications"
+						control={control}
+						render={({ field }) => {
+							const opts =
+								notifications?.map((n) => ({
+									id: n.id,
+									label: n.notificationName,
+								})) || [];
+
+							const selected = opts.filter((o) =>
+								(field.value || []).includes(o.id)
+							);
+
+							return (
+								<Autocomplete
+  									options={notifications ?? []}
+  									getOptionLabel={(option) => option.notificationName || ""}
+  									onChange={(_, value) => {
+   								 setValue("escalationNotification", value?.id);
+  											}}
+ 									 renderInput={(params) => (
+   									 <TextField {...params} placeholder="Select notification" />
+							  )}
+						/>
+							);
+						}}
+					/>
+				</Stack>
+			}
+		/>
+
+
 
 			{(watchedType === "http" ||
 				watchedType === "grpc" ||

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -212,6 +212,7 @@ const CreateMonitorPage = () => {
 
 	const watchedUseAdvancedMatching = watch("useAdvancedMatching") as boolean;
 	const watchGeoCheckEnabled = watch("geoCheckEnabled") as boolean;
+	const watchEscalationEnabled = watch("escalationEnabled") as boolean;
 
 	useEffect(() => {
 		clearErrors();
@@ -784,47 +785,84 @@ const CreateMonitorPage = () => {
 						)}
 					/>
 
-					<Controller
-						name="escalationMinutes"
-						control={control}
-						render={({ field }) => (
-							<TextField
-								{...field}
-								type="number"
-								fieldLabel="Wait time (minutes)"
-								fullWidth
+					{watchEscalationEnabled && (
+						<Stack spacing={theme.spacing(LAYOUT.MD)}>
+							<Controller
+								name="escalationMinutes"
+								control={control}
+								render={({ field, fieldState }) => (
+									<TextField
+										{...field}
+										type="number"
+										fieldLabel="Wait time (minutes)"
+										fullWidth
+										error={!!fieldState.error}
+										helperText={fieldState.error?.message ?? ""}
+									/>
+								)}
 							/>
-						)}
-					/>
 
-					<Controller
-						name="escalationNotifications"
-						control={control}
-						render={({ field }) => {
-							const opts =
-								notifications?.map((n) => ({
-									id: n.id,
-									label: n.notificationName,
-								})) || [];
+							<Controller
+								name="escalationNotifications"
+								control={control}
+								render={({ field }) => {
+									const notificationOptions = (notifications ?? []).map((n) => ({
+										...n,
+										name: n.notificationName,
+									}));
+									const selectedOptions = notificationOptions.filter((option) =>
+										(field.value ?? []).includes(option.id)
+									);
 
-							const selected = opts.filter((o) =>
-								(field.value || []).includes(o.id)
-							);
-
-							return (
-								<Autocomplete
-  									options={notifications ?? []}
-  									getOptionLabel={(option) => option.notificationName || ""}
-  									onChange={(_, value) => {
-   								 setValue("escalationNotification", value?.id);
-  											}}
- 									 renderInput={(params) => (
-   									 <TextField {...params} placeholder="Select notification" />
-							  )}
-						/>
-							);
-						}}
-					/>
+									return (
+										<Stack spacing={theme.spacing(LAYOUT.MD)}>
+											<Autocomplete
+												multiple
+												options={notificationOptions}
+												value={selectedOptions}
+												getOptionLabel={(option) => option.name}
+												onChange={(_, newValue) => {
+													field.onChange(newValue.map((item) => item.id));
+												}}
+												isOptionEqualToValue={(option, value) => option.id === value.id}
+												fieldLabel="Escalation notifications"
+											/>
+											{selectedOptions.length > 0 && (
+												<Stack flex={1} width="100%">
+													{selectedOptions.map((notification, index) => (
+														<Stack
+															direction="row"
+															alignItems="center"
+															key={notification.id}
+															width="100%"
+														>
+															<Typography flexGrow={1}>
+																{notification.name}
+															</Typography>
+															<IconButton
+																size="small"
+																onClick={() => {
+																	field.onChange(
+																		(field.value ?? []).filter(
+																			(id: string) => id !== notification.id
+																		)
+																	);
+																}}
+																aria-label="Remove escalation notification"
+															>
+																<Trash2 size={16} />
+															</IconButton>
+															{index < selectedOptions.length - 1 && <Divider />}
+														</Stack>
+													))}
+												</Stack>
+											)}
+										</Stack>
+									);
+								}}
+							/>
+						</Stack>
+					)}
 				</Stack>
 			}
 		/>


### PR DESCRIPTION
## Describe your changes

Added an escalation settings section to the monitor creation form. Users can now turn escalation on, enter a wait time in minutes, and choose escalation notification channels from the existing notifications list.

This change is focused on the frontend portion of escalated notifications and integrates the new controls into the existing monitor configuration flow.

## Write your issue number after "Fixes "

Fixes: Related to escalated notifications issue

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x ] (Do not skip this or your PR will be closed) I deployed the application locally.
- [ x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [ x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [ ] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x ] My PR is granular and targeted to one specific feature.
- [ ] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ x
<img width="1031" height="842" alt="Screenshot 2026-04-08 at 11 55 31 PM" src="https://github.com/user-attachments/assets/8f4e12bd-9b84-4967-92ed-711ecd5ca40f" />
x] I took a screenshot or a video and attached to this PR if there is a UI change.

