### PR TITLE
Fix issues in open source mini project

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -83,6 +83,7 @@
 		"node_modules/@babel/core": {
 			"version": "7.29.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -353,6 +354,7 @@
 		"node_modules/@emotion/react": {
 			"version": "11.14.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.13.5",
@@ -390,6 +392,7 @@
 		"node_modules/@emotion/styled": {
 			"version": "11.14.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.13.5",
@@ -1159,6 +1162,7 @@
 		"node_modules/@mui/material": {
 			"version": "7.3.7",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.28.4",
 				"@mui/core-downloads-tracker": "^7.3.7",
@@ -1263,6 +1267,7 @@
 		"node_modules/@mui/system": {
 			"version": "7.3.7",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.28.4",
 				"@mui/private-theming": "^7.3.7",
@@ -2303,6 +2308,7 @@
 			"version": "24.5.2",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.12.0"
 			}
@@ -2318,6 +2324,7 @@
 		"node_modules/@types/react": {
 			"version": "18.3.27",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -2439,6 +2446,7 @@
 			"version": "8.15.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2763,6 +2771,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -3194,7 +3203,8 @@
 		},
 		"node_modules/dayjs": {
 			"version": "1.11.13",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/debug": {
 			"version": "4.4.3",
@@ -3576,6 +3586,7 @@
 			"version": "8.57.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -4320,6 +4331,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.27.6"
 			},
@@ -5103,6 +5115,7 @@
 			"resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.19.0.tgz",
 			"integrity": "sha512-REhYUN8gNP3HlcIZS6QU2uy8iovl31cXsrNDkCcqWSQbCkcpdYLczqDz5PVIwNH42UQNyvukjes/RoHPDrOUmQ==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"@mapbox/geojson-rewind": "^0.5.2",
 				"@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -5750,6 +5763,7 @@
 		"node_modules/react-dom": {
 			"version": "18.3.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -5761,6 +5775,7 @@
 		"node_modules/react-hook-form": {
 			"version": "7.71.1",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18.0.0"
 			},
@@ -5960,7 +5975,8 @@
 		},
 		"node_modules/redux": {
 			"version": "5.0.1",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/redux-persist": {
 			"version": "6.0.0",
@@ -6110,6 +6126,7 @@
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
 			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -6898,6 +6915,7 @@
 			"version": "5.9.3",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -7033,6 +7051,7 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
 			"integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",

--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalation: data?.escalation,
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -202,13 +202,14 @@ const CreateMonitorPage = () => {
 		resolver: zodResolver(schema),
 		defaultValues: defaults,
 	});
-	const { control, watch, handleSubmit, clearErrors } = form;
+	const { control, watch, handleSubmit, clearErrors, setValue } = form;
 
 	useEffect(() => {
 		form.reset(defaults);
 	}, [defaults, form]);
 
 	const watchedType = watch("type") as MonitorType;
+	const watchedEscalation = watch("escalation");
 
 	const watchedUseAdvancedMatching = watch("useAdvancedMatching") as boolean;
 	const watchGeoCheckEnabled = watch("geoCheckEnabled") as boolean;
@@ -762,6 +763,122 @@ const CreateMonitorPage = () => {
 							);
 						}}
 					/>
+				}
+			/>
+
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalation.title")}
+				subtitle={t("pages.createMonitor.form.escalation.description")}
+				rightContent={
+					<Stack spacing={theme.spacing(LAYOUT.MD)}>
+						<Controller
+							name="escalation.delayMinutes"
+							control={control}
+							render={({ field, fieldState }) => (
+								<Stack spacing={theme.spacing(SPACING.XS)}>
+									<TextField
+										fieldLabel={t("pages.createMonitor.form.escalation.option.delayMinutes.label")}
+										type="number"
+										value={watchedEscalation?.delayMinutes ?? 0}
+										onChange={(event) => {
+											const value = Number(event.target.value);
+											const safeValue = Number.isNaN(value) ? 0 : value;
+											const nextChannelId = watchedEscalation?.channelId ?? "";
+
+											if (safeValue <= 0 && !nextChannelId) {
+												setValue("escalation", null);
+												return;
+											}
+
+											setValue("escalation", {
+												delayMinutes: safeValue,
+												channelId: nextChannelId,
+											});
+											field.onChange(safeValue);
+										}}
+										inputProps={{ min: 0, max: 1440 }}
+									/>
+									{fieldState.error?.message && (
+										<Typography color="error">{fieldState.error.message}</Typography>
+									)}
+								</Stack>
+							)}
+						/>
+
+						<Controller
+							name="escalation.channelId"
+							control={control}
+							render={({ field }) => {
+								const notificationOptions = (notifications ?? []).map((notification) => ({
+									...notification,
+									name: notification.notificationName,
+								}));
+								const selectedEscalation =
+									notificationOptions.find((notification) => notification.id === watchedEscalation?.channelId) || null;
+
+								return (
+									<Stack spacing={theme.spacing(LAYOUT.MD)}>
+										<Autocomplete
+											options={notificationOptions}
+											value={selectedEscalation}
+											getOptionLabel={(option) => option.name}
+											onChange={(_: unknown, newValue: (typeof notificationOptions)[number] | null) => {
+												const nextChannelId = newValue?.id ?? "";
+												const nextDelay = watchedEscalation?.delayMinutes ?? 0;
+
+												if (!nextChannelId && nextDelay <= 0) {
+													setValue("escalation", null);
+													field.onChange("");
+													return;
+												}
+
+												setValue("escalation", {
+													delayMinutes: nextDelay,
+													channelId: nextChannelId,
+												});
+												field.onChange(nextChannelId);
+											}}
+											isOptionEqualToValue={(option, value) => option.id === value.id}
+											fieldLabel={t("pages.createMonitor.form.escalation.option.channel.label")}
+										/>
+										{selectedEscalation && (
+											<Stack
+												flex={1}
+												width="100%"
+											>
+												<Stack
+													direction="row"
+													alignItems="center"
+													width="100%"
+												>
+													<Typography flexGrow={1}>{selectedEscalation.notificationName}</Typography>
+													<IconButton
+														size="small"
+														onClick={() => {
+															const nextDelay = watchedEscalation?.delayMinutes ?? 0;
+															if (nextDelay <= 0) {
+																setValue("escalation", null);
+															} else {
+																setValue("escalation", {
+																	delayMinutes: nextDelay,
+																	channelId: "",
+																});
+															}
+															field.onChange("");
+														}}
+														aria-label="Remove escalation notification"
+													>
+														<Trash2 size={16} />
+													</IconButton>
+												</Stack>
+												<Divider />
+											</Stack>
+										)}
+									</Stack>
+								);
+							}}
+						/>
+					</Stack>
 				}
 			/>
 

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -777,7 +777,9 @@ const CreateMonitorPage = () => {
 							render={({ field, fieldState }) => (
 								<Stack spacing={theme.spacing(SPACING.XS)}>
 									<TextField
-										fieldLabel={t("pages.createMonitor.form.escalation.option.delayMinutes.label")}
+										fieldLabel={t(
+											"pages.createMonitor.form.escalation.option.delayMinutes.label"
+										)}
 										type="number"
 										value={watchedEscalation?.delayMinutes ?? 0}
 										onChange={(event) => {
@@ -814,7 +816,9 @@ const CreateMonitorPage = () => {
 									name: notification.notificationName,
 								}));
 								const selectedEscalation =
-									notificationOptions.find((notification) => notification.id === watchedEscalation?.channelId) || null;
+									notificationOptions.find(
+										(notification) => notification.id === watchedEscalation?.channelId
+									) || null;
 
 								return (
 									<Stack spacing={theme.spacing(LAYOUT.MD)}>
@@ -822,7 +826,10 @@ const CreateMonitorPage = () => {
 											options={notificationOptions}
 											value={selectedEscalation}
 											getOptionLabel={(option) => option.name}
-											onChange={(_: unknown, newValue: (typeof notificationOptions)[number] | null) => {
+											onChange={(
+												_: unknown,
+												newValue: (typeof notificationOptions)[number] | null
+											) => {
 												const nextChannelId = newValue?.id ?? "";
 												const nextDelay = watchedEscalation?.delayMinutes ?? 0;
 
@@ -839,7 +846,9 @@ const CreateMonitorPage = () => {
 												field.onChange(nextChannelId);
 											}}
 											isOptionEqualToValue={(option, value) => option.id === value.id}
-											fieldLabel={t("pages.createMonitor.form.escalation.option.channel.label")}
+											fieldLabel={t(
+												"pages.createMonitor.form.escalation.option.channel.label"
+											)}
 										/>
 										{selectedEscalation && (
 											<Stack
@@ -851,7 +860,9 @@ const CreateMonitorPage = () => {
 													alignItems="center"
 													width="100%"
 												>
-													<Typography flexGrow={1}>{selectedEscalation.notificationName}</Typography>
+													<Typography flexGrow={1}>
+														{selectedEscalation.notificationName}
+													</Typography>
 													<IconButton
 														size="small"
 														onClick={() => {

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface MonitorEscalation {
+	delayMinutes: number;
+	channelId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +65,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalation?: MonitorEscalation | null;
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -15,7 +15,11 @@ const baseSchema = z.object({
 	notifications: z.array(z.string()),
 	escalation: z
 		.object({
-			delayMinutes: z.number().int().min(1, "Escalation delay must be at least 1 minute").max(1440, "Escalation delay must be at most 1440 minutes"),
+			delayMinutes: z
+				.number()
+				.int()
+				.min(1, "Escalation delay must be at least 1 minute")
+				.max(1440, "Escalation delay must be at most 1440 minutes"),
 			channelId: z.string().min(1, "Escalation channel is required"),
 		})
 		.nullable()

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -13,6 +13,13 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalation: z
+		.object({
+			delayMinutes: z.number().int().min(1, "Escalation delay must be at least 1 minute").max(1440, "Escalation delay must be at most 1440 minutes"),
+			channelId: z.string().min(1, "Escalation channel is required"),
+		})
+		.nullable()
+		.optional(),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -543,6 +543,18 @@
 					"description": "Select the notification channels you want to use",
 					"title": "Notifications"
 				},
+				"escalation": {
+					"title": "Escalation Rules",
+					"description": "If the monitor stays down for the specified time, notify additional channels.",
+					"option": {
+						"delayMinutes": {
+							"label": "Escalate after (minutes)"
+						},
+						"channel": {
+							"label": "Escalation notification channels"
+						}
+					}
+				},
 				"type": {
 					"description": "Select the type of check to perform",
 					"optionDockerDescription": "Use Docker to monitor if a container is running.",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -873,6 +873,7 @@
 			"integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.28.6",
 				"@babel/generator": "^7.28.6",
@@ -1502,6 +1503,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -1546,6 +1548,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -4337,6 +4340,7 @@
 			"integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/body-parser": "*",
 				"@types/express-serve-static-core": "^5.0.0",
@@ -4497,6 +4501,7 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
 			"integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -4734,6 +4739,7 @@
 			"integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.56.1",
 				"@typescript-eslint/types": "8.56.1",
@@ -5347,6 +5353,7 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -5925,6 +5932,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.19",
 				"caniuse-lite": "^1.0.30001751",
@@ -6867,6 +6875,7 @@
 			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.1.tgz",
 			"integrity": "sha512-fm4D8ti0dQmFPeF8DXSAA//btEmqCOgAc/9Oa3C1LW94h5usNrJEfrON7b4FkPZgnDEn6OUs5NdxiJZmAtGOpQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssnano-preset-default": "^7.0.9",
 				"lilconfig": "^3.1.3"
@@ -7634,6 +7643,7 @@
 			"integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -7995,6 +8005,7 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
 			"integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
@@ -9639,6 +9650,7 @@
 			"integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/core": "30.2.0",
 				"@jest/types": "30.2.0",
@@ -12509,6 +12521,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -14604,6 +14617,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -14772,6 +14786,7 @@
 			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
@@ -14934,6 +14949,7 @@
 			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -304,6 +304,7 @@ export const initializeServices = async ({
 		monitorStatsRepository,
 		statusPagesRepository,
 		incidentsRepository,
+		notificationsRepository,
 	});
 
 	const statusPageService = new StatusPageService(statusPagesRepository);

--- a/server/src/controllers/notificationController.ts
+++ b/server/src/controllers/notificationController.ts
@@ -35,10 +35,16 @@ class NotificationController implements INotificationController {
 	testNotification = async (req: Request, res: Response, next: NextFunction) => {
 		try {
 			const notification = testNotificationBodyValidation.parse(req.body);
-			const success = await this.notificationsService.sendTestNotification(notification);
+			const result = await this.notificationsService.sendTestNotification(notification);
 
-			if (!success) {
-				throw new AppError({ message: "Sending notification failed", status: 500 });
+			if (!result.success) {
+				throw new AppError({
+					message: `Sending notification failed: ${result.error ?? "Unknown provider error"}`,
+					status: 500,
+					service: SERVICE_NAME,
+					method: "testNotification",
+					details: result.details,
+				});
 			}
 
 			return res.status(200).json({

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -18,11 +18,15 @@ type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Dat
 
 type MonitorDocumentBase = Omit<
 	Monitor,
-	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
+	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "escalation" | "createdAt" | "updatedAt"
 > & {
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
+	escalation?: {
+		delayMinutes: number;
+		channelId: Types.ObjectId;
+	};
 	selectedDisks: string[];
 	matchMethod?: MonitorMatchMethod;
 };
@@ -284,6 +288,18 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalation: {
+			delayMinutes: {
+				type: Number,
+				min: 1,
+				max: 1440,
+			},
+			channelId: {
+				type: Schema.Types.ObjectId,
+				ref: "Notification",
+			},
+			_id: false,
+		},
 		secret: {
 			type: String,
 		},

--- a/server/src/middleware/handleErrors.ts
+++ b/server/src/middleware/handleErrors.ts
@@ -17,10 +17,7 @@ const handleErrors = (error: unknown, req: Request, res: Response, _next: NextFu
 	const runtimeEnv = (process.env.NODE_ENV ?? "").toLowerCase();
 	const debugEnvs = new Set(["development", "dev", "test", "local"]);
 	const shouldIncludeDetails =
-		error instanceof AppError &&
-		typeof error.details !== "undefined" &&
-		debugEnvs.has(runtimeEnv) &&
-		process.env.API_ERROR_DETAILS !== "false";
+		error instanceof AppError && typeof error.details !== "undefined" && debugEnvs.has(runtimeEnv) && process.env.API_ERROR_DETAILS !== "false";
 	res.status(status).json({
 		status,
 		msg: message,

--- a/server/src/middleware/handleErrors.ts
+++ b/server/src/middleware/handleErrors.ts
@@ -14,9 +14,17 @@ const handleErrors = (error: unknown, req: Request, res: Response, _next: NextFu
 		stack: error instanceof AppError ? error.stack : undefined,
 		details: error instanceof AppError ? error.details : undefined,
 	});
+	const runtimeEnv = (process.env.NODE_ENV ?? "").toLowerCase();
+	const debugEnvs = new Set(["development", "dev", "test", "local"]);
+	const shouldIncludeDetails =
+		error instanceof AppError &&
+		typeof error.details !== "undefined" &&
+		debugEnvs.has(runtimeEnv) &&
+		process.env.API_ERROR_DETAILS !== "false";
 	res.status(status).json({
 		status,
 		msg: message,
+		...(shouldIncludeDetails ? { details: error.details } : {}),
 	});
 };
 

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -351,6 +351,13 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification) => toStringId(notification));
+		const escalation =
+			doc.escalation?.channelId && doc.escalation?.delayMinutes
+				? {
+						delayMinutes: doc.escalation.delayMinutes,
+						channelId: toStringId(doc.escalation.channelId),
+					}
+				: undefined;
 
 		return {
 			id: toStringId(doc._id),
@@ -374,6 +381,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalation,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -410,6 +418,13 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification: unknown) => toStringId(notification));
+		const escalation =
+			doc.escalation?.channelId && doc.escalation?.delayMinutes
+				? {
+						delayMinutes: doc.escalation.delayMinutes,
+						channelId: toStringId(doc.escalation.channelId),
+					}
+				: undefined;
 
 		return {
 			id: toStringId(doc._id),
@@ -433,6 +448,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalation,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/business/monitorService.ts
+++ b/server/src/service/business/monitorService.ts
@@ -17,6 +17,7 @@ import type {
 	IIncidentsRepository,
 	IMonitorsRepository,
 	IMonitorStatsRepository,
+	INotificationsRepository,
 	IStatusPagesRepository,
 } from "@/repositories/index.js";
 import demoMonitorsData from "@/utils/demoMonitors.json" with { type: "json" };
@@ -100,6 +101,7 @@ export class MonitorService implements IMonitorService {
 	private monitorStatsRepository: IMonitorStatsRepository;
 	private statusPagesRepository: IStatusPagesRepository;
 	private incidentsRepository: IIncidentsRepository;
+	private notificationsRepository: INotificationsRepository;
 
 	constructor({
 		jobQueue,
@@ -112,6 +114,7 @@ export class MonitorService implements IMonitorService {
 		monitorStatsRepository,
 		statusPagesRepository,
 		incidentsRepository,
+		notificationsRepository,
 	}: {
 		jobQueue: ISuperSimpleQueue;
 		emailService: IEmailService;
@@ -123,6 +126,7 @@ export class MonitorService implements IMonitorService {
 		monitorStatsRepository: IMonitorStatsRepository;
 		statusPagesRepository: IStatusPagesRepository;
 		incidentsRepository: IIncidentsRepository;
+		notificationsRepository: INotificationsRepository;
 	}) {
 		this.jobQueue = jobQueue;
 		this.emailService = emailService;
@@ -134,6 +138,7 @@ export class MonitorService implements IMonitorService {
 		this.monitorStatsRepository = monitorStatsRepository;
 		this.statusPagesRepository = statusPagesRepository;
 		this.incidentsRepository = incidentsRepository;
+		this.notificationsRepository = notificationsRepository;
 	}
 
 	get serviceName(): string {
@@ -165,7 +170,26 @@ export class MonitorService implements IMonitorService {
 		return formatLookup[dateRange];
 	};
 
+	private validateEscalationChannel = async (teamId: string, body: Partial<Monitor>) => {
+		const escalation = body.escalation;
+		if (!escalation) {
+			return;
+		}
+
+		try {
+			await this.notificationsRepository.findById(escalation.channelId, teamId);
+		} catch {
+			throw new AppError({
+				message: "Escalation channel does not exist for this team",
+				status: 400,
+				service: SERVICE_NAME,
+				method: "validateEscalationChannel",
+			});
+		}
+	};
+
 	createMonitor = async (teamId: string, userId: string, body: Monitor): Promise<void> => {
+		await this.validateEscalationChannel(teamId, body);
 		const monitor = await this.monitorsRepository.create(body, teamId, userId);
 		if (!monitor) {
 			throw new AppError({ message: "Failed to create monitor", status: 500, service: SERVICE_NAME, method: "createMonitor" });
@@ -437,6 +461,7 @@ export class MonitorService implements IMonitorService {
 	};
 
 	editMonitor = async ({ teamId, monitorId, body }: { teamId: string; monitorId: string; body: Partial<Monitor> }) => {
+		await this.validateEscalationChannel(teamId, body);
 		const editedMonitor = await this.monitorsRepository.updateById(monitorId, teamId, body);
 		await this.jobQueue.updateJob(editedMonitor);
 		return editedMonitor;
@@ -571,6 +596,8 @@ export class MonitorService implements IMonitorService {
 			createdAt: "",
 			updatedAt: "",
 		}));
+
+		await Promise.all(cleanedMonitors.map((monitor) => this.validateEscalationChannel(teamId, monitor)));
 
 		const createdMonitors = await this.createMonitors(cleanedMonitors);
 

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -170,14 +170,36 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 					});
 				}
 
-				if (decision.shouldResolveIncident) {
-					this.cancelEscalationForMonitor(statusChangeResult.monitor.id);
-				}
-
 				// Step 7. Handle incidents (best effort, don't wait)
 				this.incidentService
 					.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status)
 					.then((incident) => {
+						if (decision.shouldResolveIncident) {
+							// Stop recurring escalation once no active incident remains.
+							if (!incident || incident.status === false) {
+								this.cancelEscalationForMonitor(statusChangeResult.monitor.id);
+							}
+
+							// Send one escalation recovery notification only when resolution was persisted.
+							if (incident?.status === false) {
+								const escalationChannelId = statusChangeResult.monitor.escalation?.channelId;
+								if (escalationChannelId) {
+									this.notificationsService
+										.sendEscalationRecoveryNotification(statusChangeResult.monitor, escalationChannelId)
+										.catch((error: unknown) => {
+											this.logger.warn({
+												message: `Error sending escalation recovery notification for monitor ${statusChangeResult.monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+												service: SERVICE_NAME,
+												method: "getMonitorJob",
+												stack: error instanceof Error ? error.stack : undefined,
+											});
+										});
+								}
+							}
+
+							return;
+						}
+
 						if (!incident || !decision.shouldCreateIncident) {
 							return;
 						}

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -66,6 +66,7 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 	private incidentsRepository: IIncidentsRepository;
 	private geoChecksService: IGeoChecksService;
 	private geoChecksRepository: IGeoChecksRepository;
+	private escalationTimers: Map<string, ReturnType<typeof setInterval>>;
 
 	constructor(
 		logger: ILogger,
@@ -101,6 +102,7 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 		this.incidentsRepository = incidentsRepository;
 		this.geoChecksService = geoChecksService;
 		this.geoChecksRepository = geoChecksRepository;
+		this.escalationTimers = new Map();
 	}
 
 	get serviceName() {
@@ -168,15 +170,27 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 					});
 				}
 
+				if (decision.shouldResolveIncident) {
+					this.cancelEscalationForMonitor(statusChangeResult.monitor.id);
+				}
+
 				// Step 7. Handle incidents (best effort, don't wait)
-				this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status).catch((error: unknown) => {
-					this.logger.warn({
-						message: `Error handling incident for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
-						service: SERVICE_NAME,
-						method: "getMonitorJob",
-						stack: error instanceof Error ? error.stack : undefined,
+				this.incidentService
+					.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status)
+					.then((incident) => {
+						if (!incident || !decision.shouldCreateIncident) {
+							return;
+						}
+						this.scheduleEscalationForIncident(statusChangeResult.monitor, incident.id);
+					})
+					.catch((error: unknown) => {
+						this.logger.warn({
+							message: `Error handling incident for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+							service: SERVICE_NAME,
+							method: "getMonitorJob",
+							stack: error instanceof Error ? error.stack : undefined,
+						});
 					});
-				});
 			} catch (error: unknown) {
 				this.logger.warn({
 					message: error instanceof Error ? error.message : "Unknown error",
@@ -188,6 +202,82 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 			}
 		};
 	};
+
+	private cancelEscalationForMonitor(monitorId: string): void {
+		const timer = this.escalationTimers.get(monitorId);
+		if (!timer) {
+			return;
+		}
+
+		clearInterval(timer);
+		this.escalationTimers.delete(monitorId);
+	}
+
+	private scheduleEscalationForIncident(monitor: Monitor, incidentId: string): void {
+		const escalation = monitor.escalation;
+		if (!escalation) {
+			return;
+		}
+
+		this.cancelEscalationForMonitor(monitor.id);
+		const delayMs = Math.max(1, escalation.delayMinutes) * 60 * 1000;
+		let isTickInProgress = false;
+
+		const timer = setInterval(async () => {
+			if (isTickInProgress) {
+				return;
+			}
+
+			isTickInProgress = true;
+			try {
+				const shouldContinue = await this.triggerEscalationForIncident(monitor.id, monitor.teamId, incidentId);
+				if (!shouldContinue) {
+					this.cancelEscalationForMonitor(monitor.id);
+				}
+			} catch (error: unknown) {
+				this.logger.warn({
+					message: `Error triggering escalation for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+					service: SERVICE_NAME,
+					method: "scheduleEscalationForIncident",
+					stack: error instanceof Error ? error.stack : undefined,
+				});
+			} finally {
+				isTickInProgress = false;
+			}
+		}, delayMs);
+
+		this.escalationTimers.set(monitor.id, timer);
+	}
+
+	private async triggerEscalationForIncident(monitorId: string, teamId: string, incidentId: string): Promise<boolean> {
+		const activeIncident = await this.incidentsRepository.findActiveByIncidentId(incidentId, teamId);
+		if (!activeIncident) {
+			return false;
+		}
+
+		const monitor = await this.monitorsRepository.findById(monitorId, teamId);
+		if (!monitor.escalation) {
+			return false;
+		}
+
+		const sent = await this.notificationsService.sendEscalationNotification(monitor, monitor.escalation.channelId);
+		if (!sent) {
+			this.logger.warn({
+				message: `Escalation notification failed for incident ${incidentId}`,
+				service: SERVICE_NAME,
+				method: "triggerEscalationForIncident",
+			});
+			return true;
+		}
+
+		this.logger.info({
+			message: `Escalation notification sent for incident ${incidentId}`,
+			service: SERVICE_NAME,
+			method: "triggerEscalationForIncident",
+		});
+
+		return true;
+	}
 
 	getCleanupOrphanedJob = () => {
 		return async () => {

--- a/server/src/service/infrastructure/emailService.ts
+++ b/server/src/service/infrastructure/emailService.ts
@@ -21,6 +21,21 @@ export interface IEmailService {
 	init(): void;
 	buildEmail(template: string, context: Record<string, unknown>): Promise<string | undefined>;
 	sendEmail(to: string, subject: string, html: string, transportConfig?: EmailTransportConfig): Promise<string | false | undefined>;
+	getLastError(): EmailTransportErrorDetails | null;
+}
+
+export interface EmailTransportErrorDetails extends Record<string, unknown> {
+	stage: "verify" | "send";
+	message: string;
+	name?: string;
+	code?: string;
+	errno?: string;
+	syscall?: string;
+	address?: string;
+	port?: number;
+	command?: string;
+	responseCode?: number;
+	response?: string;
 }
 
 export class EmailService implements IEmailService {
@@ -34,6 +49,7 @@ export class EmailService implements IEmailService {
 	private nodemailer: Mailer;
 	private logger: ILogger;
 	private transporter: ReturnType<typeof import("nodemailer").createTransport> | null = null;
+	private lastError: EmailTransportErrorDetails | null = null;
 	private templateLookup: Record<string, ((context: Record<string, unknown>) => string) | undefined>;
 	private loadTemplate: (templateName: string) => ((context: Record<string, unknown>) => string) | undefined;
 
@@ -61,6 +77,44 @@ export class EmailService implements IEmailService {
 	get serviceName() {
 		return EmailService.SERVICE_NAME;
 	}
+
+	getLastError = () => {
+		return this.lastError;
+	};
+
+	private mapTransportError = (stage: "verify" | "send", error: unknown): EmailTransportErrorDetails => {
+		if (!(error instanceof Error)) {
+			return {
+				stage,
+				message: "Unknown SMTP transport error",
+			};
+		}
+
+		const transportError = error as Error & {
+			code?: string;
+			errno?: string;
+			syscall?: string;
+			address?: string;
+			port?: number;
+			command?: string;
+			responseCode?: number;
+			response?: string;
+		};
+
+		return {
+			stage,
+			message: transportError.message,
+			name: transportError.name,
+			code: transportError.code,
+			errno: transportError.errno,
+			syscall: transportError.syscall,
+			address: transportError.address,
+			port: transportError.port,
+			command: transportError.command,
+			responseCode: transportError.responseCode,
+			response: transportError.response,
+		};
+	};
 
 	init = () => {
 		this.loadTemplate = (templateName) => {
@@ -107,6 +161,7 @@ export class EmailService implements IEmailService {
 	};
 
 	sendEmail = async (to: string, subject: string, html: string, transportConfig?: EmailTransportConfig) => {
+		this.lastError = null;
 		let config: EmailTransportConfig;
 		if (typeof transportConfig !== "undefined") {
 			config = transportConfig;
@@ -151,11 +206,13 @@ export class EmailService implements IEmailService {
 		try {
 			await this.transporter.verify();
 		} catch (error: unknown) {
+			this.lastError = this.mapTransportError("verify", error);
 			this.logger.warn({
 				message: "Email transporter verification failed",
 				service: SERVICE_NAME,
 				method: "verifyTransporter",
 				stack: error instanceof Error ? error.stack : undefined,
+				details: this.lastError,
 			});
 			return false;
 		}
@@ -169,11 +226,13 @@ export class EmailService implements IEmailService {
 			});
 			return info?.messageId;
 		} catch (error: unknown) {
+			this.lastError = this.mapTransportError("send", error);
 			this.logger.error({
 				message: error instanceof Error ? error.message : "Unknown error",
 				service: SERVICE_NAME,
 				method: "sendEmail",
 				stack: error instanceof Error ? error.stack : undefined,
+				details: this.lastError,
 			});
 		}
 	};

--- a/server/src/service/infrastructure/network/HttpProvider.ts
+++ b/server/src/service/infrastructure/network/HttpProvider.ts
@@ -6,7 +6,6 @@ import { MonitorStatusResponse } from "@/types/network.js";
 import { Agent as HttpsAgent } from "https";
 import { Monitor, MonitorType } from "@/types/monitor.js";
 import { NETWORK_ERROR } from "@/service/infrastructure/network/utils.js";
-import CacheableLookup from "cacheable-lookup";
 
 export class HttpProvider implements IStatusProvider<HttpStatusPayload> {
 	readonly type = "http";
@@ -15,9 +14,7 @@ export class HttpProvider implements IStatusProvider<HttpStatusPayload> {
 		private got: Got,
 		private advancedMatcher: IAdvancedMatcher
 	) {
-		const cacheable = new CacheableLookup({ maxTtl: 300, errorTtl: 30 });
 		this.got = got.extend({
-			dnsCache: cacheable,
 			timeout: {
 				request: 30000,
 			},

--- a/server/src/service/infrastructure/notificationProviders/INotificationProvider.ts
+++ b/server/src/service/infrastructure/notificationProviders/INotificationProvider.ts
@@ -4,4 +4,5 @@ import type { NotificationMessage } from "@/types/notificationMessage.js";
 export interface INotificationProvider {
 	sendMessage: (notification: Notification, message: NotificationMessage) => Promise<boolean>;
 	sendTestAlert(notification: Partial<Notification>): Promise<boolean>;
+	sendTestAlertWithResult?(notification: Partial<Notification>): Promise<{ success: boolean; error?: string; details?: Record<string, unknown> }>;
 }

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -4,7 +4,14 @@ import { INotificationProvider } from "@/service/index.js";
 import { buildTestEmail } from "@/service/infrastructure/notificationProviders/utils.js";
 import type { NotificationMessage } from "@/types/notificationMessage.js";
 import type { ILogger } from "@/utils/logger.js";
-import { IEmailService } from "@/service/infrastructure/emailService.js";
+import { IEmailService, type EmailTransportErrorDetails } from "@/service/infrastructure/emailService.js";
+
+type NotificationProviderTestResult = {
+	success: boolean;
+	error?: string;
+	details?: Record<string, unknown>;
+};
+
 export class EmailProvider implements INotificationProvider {
 	private emailService: IEmailService;
 	private logger: ILogger;
@@ -14,42 +21,89 @@ export class EmailProvider implements INotificationProvider {
 		this.logger = logger;
 	}
 
+	private buildTransportFailureReason = (transportError: EmailTransportErrorDetails | null) => {
+		if (!transportError) {
+			return "SMTP send failed";
+		}
+
+		const stage = transportError.stage;
+		const code = typeof transportError.code === "string" ? transportError.code : "UNKNOWN";
+		const base = typeof transportError.message === "string" ? transportError.message : "Unknown transport error";
+
+		return `SMTP ${stage} failed (${code}): ${base}`;
+	};
+
 	async sendTestAlert(notification: Partial<Notification>): Promise<boolean> {
+		const result = await this.sendTestAlertWithResult(notification);
+		return result.success;
+	}
+
+	async sendTestAlertWithResult(notification: Partial<Notification>): Promise<NotificationProviderTestResult> {
 		const subject = "Test notification";
 		const html = await buildTestEmail(this.emailService);
 
 		if (!notification.address) {
+			const details = { type: notification.type };
 			this.logger.warn({
 				message: "Missing address",
 				service: SERVICE_NAME,
 				method: "sendTestAlert",
+				details,
 			});
-			return false;
+			return {
+				success: false,
+				error: "Missing recipient email address",
+				details,
+			};
 		}
 
 		if (!html) {
+			const details = { type: notification.type, address: notification.address };
 			this.logger.warn({
 				message: "Failed to build test email content",
 				service: SERVICE_NAME,
 				method: "sendTestAlert",
+				details,
 			});
-			return false;
+			return {
+				success: false,
+				error: "Failed to build email template",
+				details,
+			};
 		}
 
 		const messageId = await this.emailService.sendEmail(notification.address, subject, html);
 		if (!messageId) {
+			const transportError = this.emailService.getLastError();
+			const details = {
+				address: notification.address,
+				transportError,
+			};
+			const reason = this.buildTransportFailureReason(transportError);
 			this.logger.warn({
 				message: "Email test alert failed",
 				service: SERVICE_NAME,
 				method: "sendTestAlert",
+				details,
 			});
-			return false;
+			return {
+				success: false,
+				error: reason,
+				details,
+			};
 		}
-		return true;
+
+		return { success: true };
 	}
 
 	async sendMessage(notification: Notification, message: NotificationMessage): Promise<boolean> {
 		if (!notification.address) {
+			this.logger.warn({
+				message: "Missing recipient email address",
+				service: SERVICE_NAME,
+				method: "sendMessage",
+				details: { notificationId: notification.id, monitor: message.monitor.name },
+			});
 			return false;
 		}
 
@@ -61,19 +115,27 @@ export class EmailProvider implements INotificationProvider {
 				message: "Failed to build email content",
 				service: SERVICE_NAME,
 				method: "sendMessage",
+				details: { notificationId: notification.id, monitor: message.monitor.name },
 			});
 			return false;
 		}
 
 		const messageId = await this.emailService.sendEmail(notification.address, subject, html);
 		if (!messageId) {
+			const transportError = this.emailService.getLastError();
 			this.logger.warn({
 				message: "Email notification failed",
 				service: SERVICE_NAME,
 				method: "sendMessage",
+				details: {
+					notificationId: notification.id,
+					address: notification.address,
+					transportError,
+				},
 			});
 			return false;
 		}
+
 		return true;
 	}
 

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -7,6 +7,12 @@ import type { ISettingsService } from "@/service/system/settingsService.js";
 import { ILogger } from "@/utils/logger.js";
 import type { INotificationMessageBuilder } from "@/service/infrastructure/notificationMessageBuilder.js";
 
+export interface NotificationTestResult {
+	success: boolean;
+	error?: string;
+	details?: Record<string, unknown>;
+}
+
 export interface INotificationsService {
 	createNotification: (notificationData: Partial<Notification>, userId: string, teamId: string) => Promise<Notification>;
 	findById: (id: string, teamId: string) => Promise<Notification>;
@@ -14,8 +20,9 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	sendEscalationNotification: (monitor: Monitor, channelId: string) => Promise<boolean>;
 
-	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
+	sendTestNotification: (notification: Partial<Notification>) => Promise<NotificationTestResult>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
 }
 
@@ -81,6 +88,21 @@ export class NotificationsService implements INotificationsService {
 			return false;
 		}
 
+		const reason = notificationMessage.metadata?.notificationReason ?? decision.notificationReason;
+		this.logger.info({
+			message: "Dispatching notification",
+			service: SERVICE_NAME,
+			method: "send",
+			details: {
+				reason,
+				monitorId: monitor.id,
+				monitorName: monitor.name,
+				notificationId: notification.id,
+				notificationType: notification.type,
+				notificationName: notification.notificationName,
+			},
+		});
+
 		// Route to provider based on notification type
 		switch (notification.type) {
 			case "webhook":
@@ -141,24 +163,97 @@ export class NotificationsService implements INotificationsService {
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
 	};
 
-	sendTestNotification = async (notification: Partial<Notification>) => {
+	sendEscalationNotification = async (monitor: Monitor, channelId: string) => {
+		const notification = await this.notificationsRepository.findById(channelId, monitor.teamId);
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+
+		this.logger.info({
+			message: "Preparing escalation notification",
+			service: SERVICE_NAME,
+			method: "sendEscalationNotification",
+			details: {
+				monitorId: monitor.id,
+				monitorName: monitor.name,
+				escalationChannelId: channelId,
+				resolvedNotificationId: notification.id,
+				resolvedNotificationName: notification.notificationName,
+				resolvedNotificationType: notification.type,
+			},
+		});
+
+		const escalationMessage: NotificationMessage = {
+			type: "monitor_down",
+			severity: "critical",
+			monitor: {
+				id: monitor.id,
+				name: monitor.name,
+				url: monitor.url,
+				type: monitor.type,
+				status: monitor.status,
+			},
+			content: {
+				title: `Escalation: ${monitor.name}`,
+				summary: `Monitor "${monitor.name}" remains unresolved after the escalation delay.`,
+				details: [
+					`URL: ${monitor.url}`,
+					`Current status: ${monitor.status}`,
+					"Escalation triggered because incident was not resolved in time.",
+				],
+				timestamp: new Date(),
+			},
+			clientHost,
+			metadata: {
+				teamId: monitor.teamId,
+				notificationReason: "escalation",
+			},
+		};
+
+		return this.send(notification, monitor, {} as MonitorStatusResponse, {
+			shouldCreateIncident: false,
+			shouldResolveIncident: false,
+			shouldSendNotification: true,
+			incidentReason: null,
+			notificationReason: "status_change",
+		}, escalationMessage);
+	};
+
+	sendTestNotification = async (notification: Partial<Notification>): Promise<NotificationTestResult> => {
 		switch (notification.type) {
-			case "email":
-				return await this.emailProvider.sendTestAlert(notification);
-			case "slack":
-				return await this.slackProvider.sendTestAlert(notification);
-			case "discord":
-				return await this.discordProvider.sendTestAlert(notification);
-			case "pager_duty":
-				return await this.pagerDutyProvider.sendTestAlert(notification);
-			case "matrix":
-				return await this.matrixProvider.sendTestAlert(notification);
-			case "webhook":
-				return await this.webhookProvider.sendTestAlert(notification);
-			case "teams":
-				return await this.teamsProvider.sendTestAlert(notification);
+			case "email": {
+				if (this.emailProvider.sendTestAlertWithResult) {
+					return await this.emailProvider.sendTestAlertWithResult(notification);
+				}
+
+				const success = await this.emailProvider.sendTestAlert(notification);
+				return success ? { success: true } : { success: false, error: "Email provider test failed" };
+			}
+			case "slack": {
+				const success = await this.slackProvider.sendTestAlert(notification);
+				return success ? { success: true } : { success: false, error: "Slack provider test failed" };
+			}
+			case "discord": {
+				const success = await this.discordProvider.sendTestAlert(notification);
+				return success ? { success: true } : { success: false, error: "Discord provider test failed" };
+			}
+			case "pager_duty": {
+				const success = await this.pagerDutyProvider.sendTestAlert(notification);
+				return success ? { success: true } : { success: false, error: "PagerDuty provider test failed" };
+			}
+			case "matrix": {
+				const success = await this.matrixProvider.sendTestAlert(notification);
+				return success ? { success: true } : { success: false, error: "Matrix provider test failed" };
+			}
+			case "webhook": {
+				const success = await this.webhookProvider.sendTestAlert(notification);
+				return success ? { success: true } : { success: false, error: "Webhook provider test failed" };
+			}
+			case "teams": {
+				const success = await this.teamsProvider.sendTestAlert(notification);
+				return success ? { success: true } : { success: false, error: "Teams provider test failed" };
+			}
 			default:
-				return false;
+				return { success: false, error: `Unknown provider type: ${notification.type ?? "undefined"}` };
 		}
 	};
 
@@ -166,9 +261,18 @@ export class NotificationsService implements INotificationsService {
 		const notifications = await this.notificationsRepository.findNotificationsByIds(notificationIds);
 		const tasks = notifications.map((notification) => this.sendTestNotification(notification));
 		const outcomes = await Promise.all(tasks);
-		const succeeded = outcomes.filter(Boolean).length;
+		const succeeded = outcomes.filter((outcome) => outcome.success).length;
 		const failed = outcomes.length - succeeded;
 		if (failed > 0) {
+			this.logger.warn({
+				message: "Some notification test checks failed",
+				service: SERVICE_NAME,
+				method: "testAllNotifications",
+				details: {
+					failed,
+					total: outcomes.length,
+				},
+			});
 			return false;
 		}
 		return true;

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -196,11 +196,7 @@ export class NotificationsService implements INotificationsService {
 			content: {
 				title: `Escalation: ${monitor.name}`,
 				summary: `Monitor "${monitor.name}" remains unresolved after the escalation delay.`,
-				details: [
-					`URL: ${monitor.url}`,
-					`Current status: ${monitor.status}`,
-					"Escalation triggered because incident was not resolved in time.",
-				],
+				details: [`URL: ${monitor.url}`, `Current status: ${monitor.status}`, "Escalation triggered because incident was not resolved in time."],
 				timestamp: new Date(),
 			},
 			clientHost,
@@ -210,13 +206,19 @@ export class NotificationsService implements INotificationsService {
 			},
 		};
 
-		return this.send(notification, monitor, {} as MonitorStatusResponse, {
-			shouldCreateIncident: false,
-			shouldResolveIncident: false,
-			shouldSendNotification: true,
-			incidentReason: null,
-			notificationReason: "status_change",
-		}, escalationMessage);
+		return this.send(
+			notification,
+			monitor,
+			{} as MonitorStatusResponse,
+			{
+				shouldCreateIncident: false,
+				shouldResolveIncident: false,
+				shouldSendNotification: true,
+				incidentReason: null,
+				notificationReason: "status_change",
+			},
+			escalationMessage
+		);
 	};
 
 	sendEscalationRecoveryNotification = async (monitor: Monitor, channelId: string) => {
@@ -251,11 +253,7 @@ export class NotificationsService implements INotificationsService {
 			content: {
 				title: `Escalation Resolved: ${monitor.name}`,
 				summary: `Monitor "${monitor.name}" is back up and operational.`,
-				details: [
-					`URL: ${monitor.url}`,
-					`Current status: ${monitor.status}`,
-					"Escalation has been resolved because the monitor recovered.",
-				],
+				details: [`URL: ${monitor.url}`, `Current status: ${monitor.status}`, "Escalation has been resolved because the monitor recovered."],
 				timestamp: new Date(),
 			},
 			clientHost,
@@ -265,13 +263,19 @@ export class NotificationsService implements INotificationsService {
 			},
 		};
 
-		return this.send(notification, monitor, {} as MonitorStatusResponse, {
-			shouldCreateIncident: false,
-			shouldResolveIncident: true,
-			shouldSendNotification: true,
-			incidentReason: null,
-			notificationReason: "status_change",
-		}, recoveryMessage);
+		return this.send(
+			notification,
+			monitor,
+			{} as MonitorStatusResponse,
+			{
+				shouldCreateIncident: false,
+				shouldResolveIncident: true,
+				shouldSendNotification: true,
+				incidentReason: null,
+				notificationReason: "status_change",
+			},
+			recoveryMessage
+		);
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>): Promise<NotificationTestResult> => {

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -21,6 +21,7 @@ export interface INotificationsService {
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
 	sendEscalationNotification: (monitor: Monitor, channelId: string) => Promise<boolean>;
+	sendEscalationRecoveryNotification: (monitor: Monitor, channelId: string) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<NotificationTestResult>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -216,6 +217,61 @@ export class NotificationsService implements INotificationsService {
 			incidentReason: null,
 			notificationReason: "status_change",
 		}, escalationMessage);
+	};
+
+	sendEscalationRecoveryNotification = async (monitor: Monitor, channelId: string) => {
+		const notification = await this.notificationsRepository.findById(channelId, monitor.teamId);
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+
+		this.logger.info({
+			message: "Preparing escalation recovery notification",
+			service: SERVICE_NAME,
+			method: "sendEscalationRecoveryNotification",
+			details: {
+				monitorId: monitor.id,
+				monitorName: monitor.name,
+				escalationChannelId: channelId,
+				resolvedNotificationId: notification.id,
+				resolvedNotificationName: notification.notificationName,
+				resolvedNotificationType: notification.type,
+			},
+		});
+
+		const recoveryMessage: NotificationMessage = {
+			type: "monitor_up",
+			severity: "success",
+			monitor: {
+				id: monitor.id,
+				name: monitor.name,
+				url: monitor.url,
+				type: monitor.type,
+				status: monitor.status,
+			},
+			content: {
+				title: `Escalation Resolved: ${monitor.name}`,
+				summary: `Monitor "${monitor.name}" is back up and operational.`,
+				details: [
+					`URL: ${monitor.url}`,
+					`Current status: ${monitor.status}`,
+					"Escalation has been resolved because the monitor recovered.",
+				],
+				timestamp: new Date(),
+			},
+			clientHost,
+			metadata: {
+				teamId: monitor.teamId,
+				notificationReason: "escalation_recovery",
+			},
+		};
+
+		return this.send(notification, monitor, {} as MonitorStatusResponse, {
+			shouldCreateIncident: false,
+			shouldResolveIncident: true,
+			shouldSendNotification: true,
+			incidentReason: null,
+			notificationReason: "status_change",
+		}, recoveryMessage);
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>): Promise<NotificationTestResult> => {

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface MonitorEscalation {
+	delayMinutes: number;
+	channelId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +42,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalation?: MonitorEscalation | null;
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -3,6 +3,11 @@ import { booleanCoercion } from "./shared.js";
 import { GeoContinents } from "@/types/geoCheck.js";
 import { MonitorMatchMethods, MonitorTypes } from "@/types/monitor.js";
 
+const escalationValidation = z.object({
+	delayMinutes: z.number().int().min(1).max(1440),
+	channelId: z.string().min(1, "Escalation channel ID is required"),
+});
+
 export const getMonitorByIdParamValidation = z.object({
 	monitorId: z.string().min(1, "Monitor ID is required"),
 });
@@ -67,6 +72,7 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalation: escalationValidation.nullable().optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +95,7 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalation: escalationValidation.nullable().optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),
@@ -144,6 +151,7 @@ const importedMonitorSchema = z.object({
 	interval: z.number().default(60000),
 	uptimePercentage: z.number().optional(),
 	notifications: z.array(z.string()).default([]),
+	escalation: escalationValidation.nullable().optional(),
 	secret: z.string().optional(),
 	cpuAlertThreshold: z.number().default(100),
 	cpuAlertCounter: z.number().default(5),


### PR DESCRIPTION
## Describe your changes

Added escalation notifications for monitors. When a monitor goes down and the incident isn't resolved within a configurable delay, it automatically re-alerts a designated notification channel. Includes recovery notifications when the monitor comes back up.

Changes include:
- New `escalation` field on the Monitor model (`delayMinutes`, `channelId`)
- Escalation scheduling logic in `SuperSimpleQueueHelper` using `setInterval` timers, with auto-cancel on recovery
- `sendEscalationNotification` and `sendEscalationRecoveryNotification` methods on `NotificationsService`
- Improved `sendTestNotification` to return a typed `NotificationTestResult` instead of a plain boolean
- Escalation config UI in the Create Monitor form (delay input + notification channel selector)
<img width="1845" height="353" alt="image" src="https://github.com/user-attachments/assets/8ea5be3a-b275-4f69-95eb-0e6e1f4bf064" />

## Write your issue number after "Fixes "

Fixes #

## Please ensure all items are checked off before requesting a review.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [X] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
