### PR TITLE
Implemented escalation notification support for monitors

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in the **bluewave-uptime** project and community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in the **Checkmate** project and community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community, especially during Hacktoberfest, where we encourage new contributors to join and feel supported.
 
@@ -66,4 +66,4 @@ This Code of Conduct is adapted from the [Contributor Covenant](https://www.cont
 
 ---
 
-By following this Code of Conduct, we can ensure a welcoming and inclusive environment, encouraging new contributors to engage with the project and the community. Thank you for helping make **bluewave-uptime** a positive space for all!
+By following this Code of Conduct, we can ensure a welcoming and inclusive environment, encouraging new contributors to engage with the project and the community. Thank you for helping make **Checkmate** a positive space for all!

--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalation: data?.escalation ?? null,
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -202,7 +202,7 @@ const CreateMonitorPage = () => {
 		resolver: zodResolver(schema),
 		defaultValues: defaults,
 	});
-	const { control, watch, handleSubmit, clearErrors } = form;
+	const { control, watch, setValue, handleSubmit, clearErrors } = form;
 
 	useEffect(() => {
 		form.reset(defaults);
@@ -212,6 +212,7 @@ const CreateMonitorPage = () => {
 
 	const watchedUseAdvancedMatching = watch("useAdvancedMatching") as boolean;
 	const watchGeoCheckEnabled = watch("geoCheckEnabled") as boolean;
+	const watchedEscalation = watch("escalation");
 
 	useEffect(() => {
 		clearErrors();
@@ -762,6 +763,73 @@ const CreateMonitorPage = () => {
 							);
 						}}
 					/>
+				}
+			/>
+			<ConfigBox
+				title="Escalated Notifications"
+				subtitle="Send an escalation alert if the incident stays active after a delay."
+				rightContent={
+					<Stack spacing={2}>
+						<Stack
+							direction="row"
+							alignItems="center"
+							spacing={1}
+						>
+							<Switch
+								checked={!!watchedEscalation}
+								onChange={(e) => {
+									if (e.target.checked) {
+										setValue("escalation", {
+											delayMinutes: 5,
+											channelId: "",
+										});
+									} else {
+										setValue("escalation", null);
+									}
+								}}
+							/>
+							<Typography>Enable escalated notification</Typography>
+						</Stack>
+
+						{watchedEscalation && (
+							<>
+								<Controller
+									name="escalation.delayMinutes"
+									control={control}
+									render={({ field, fieldState }) => (
+										<TextField
+											fieldLabel="Escalate after (minutes)"
+											type="number"
+											value={field.value ?? ""}
+											onChange={(e) => field.onChange(Number(e.target.value))}
+											error={!!fieldState.error}
+											helperText={fieldState.error?.message}
+											fullWidth
+										/>
+									)}
+								/>
+
+								<Controller
+									name="escalation.channelId"
+									control={control}
+									render={({ field }) => (
+										<Autocomplete
+											fieldLabel="Escalation channel"
+											options={notifications ?? []}
+											value={
+												(notifications ?? []).find(
+													(notification) => notification.id === field.value
+												) ?? null
+											}
+											getOptionLabel={(option) => option.notificationName}
+											isOptionEqualToValue={(option, value) => option.id === value.id}
+											onChange={(_, newValue) => field.onChange(newValue?.id ?? "")}
+										/>
+									)}
+								/>
+							</>
+						)}
+					</Stack>
 				}
 			/>
 

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -79,6 +79,7 @@ export interface Monitor {
 	recentChecks: CheckSnapshot[];
 	createdAt: string;
 	updatedAt: string;
+	escalation?: MonitorEscalation | null;
 }
 
 export type MonitorWithChecks = Monitor;
@@ -190,6 +191,10 @@ export interface Game {
 	options?: {
 		port?: number;
 	};
+}
+export interface MonitorEscalation {
+	delayMinutes: number;
+	channelId: string;
 }
 
 export type GamesMap = Record<string, Game>;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -13,6 +13,13 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalation: z
+		.object({
+			delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+			channelId: z.string().min(1, "Escalation channel is required"),
+		})
+		.nullable()
+		.optional(),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -54,6 +54,10 @@ const IncidentSchema = new Schema<IncidentDocument>(
 			default: null,
 			index: true,
 		},
+		escalatedAt: {
+			type: Date,
+			default: null,
+		},
 		resolutionType: {
 			type: String,
 			enum: IncidentResolutionTypes,

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -284,6 +284,15 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalation: {
+			delayMinutes: {
+				type: Number,
+			},
+			channelId: {
+				type: Schema.Types.ObjectId,
+				ref: "Notification",
+			},
+		},
 		secret: {
 			type: String,
 		},

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -374,6 +374,12 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalation: doc.escalation
+				? {
+						delayMinutes: doc.escalation.delayMinutes,
+						channelId: toStringId(doc.escalation.channelId),
+					}
+				: null,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -433,6 +439,12 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalation: doc.escalation
+				? {
+						delayMinutes: doc.escalation.delayMinutes,
+						channelId: toStringId(doc.escalation.channelId),
+					}
+				: null,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -112,32 +112,40 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 			try {
 				const monitorId = monitor.id;
 				const teamId = monitor.teamId;
+
 				if (!monitorId) {
-					throw new AppError({ message: "No monitor id", service: SERVICE_NAME, method: "getMonitorJob" });
+					throw new AppError({
+						message: "No monitor id",
+						service: SERVICE_NAME,
+						method: "getMonitorJob",
+					});
 				}
 
-				// Step 1.  Check for maintenance window, if found, skip the check
-
+				// Step 1. Check for maintenance window, if found, skip the check
 				const maintenanceWindowActive = await this.isInMaintenanceWindow(monitorId, teamId);
+
 				if (maintenanceWindowActive) {
 					this.logger.debug({
 						message: `Monitor ${monitorId} is in maintenance window`,
 						service: SERVICE_NAME,
 						method: "getMonitorJob",
 					});
+
 					if (monitor.status !== "maintenance") {
-						await this.monitorsRepository.updateById(monitorId, teamId, { status: "maintenance" });
+						await this.monitorsRepository.updateById(monitorId, teamId, {
+							status: "maintenance",
+						});
 					}
 					return;
 				}
 
-				// Step 2.  Request monitor status
+				// Step 2. Request monitor status
 				const status = await this.networkService.requestStatus(monitor);
 				if (!status) {
 					throw new Error("No network response");
 				}
 
-				// Step 3.  Build check
+				// Step 3. Build check
 				const check = this.checkService.buildCheck(status);
 				if (!check) {
 					this.logger.warn({
@@ -148,19 +156,23 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 					});
 					return;
 				}
-				// Step 4 Add check to buffer
+
+				// Step 4. Add check to buffer
 				this.buffer.addToBuffer(check);
-				// Step 4.  Update monitor status
+
+				// Step 5. Update monitor status
 				const statusChangeResult = await this.statusService.updateMonitorStatus(status, check);
 
-				// Step 5.  Get decisions
+				// Step 6. Get decisions
 				const decision = this.evaluateMonitorAction(statusChangeResult);
 
-				// Step 6. Handle notifications (best effort, continue even in event of failure, don't wait)
+				// Step 7. Handle normal notifications (best effort, continue even in event of failure)
 				if (decision.shouldSendNotification) {
 					this.notificationsService.handleNotifications(statusChangeResult.monitor, status, decision).catch((error: unknown) => {
 						this.logger.error({
-							message: `Error sending notifications for job ${statusChangeResult.monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+							message: `Error sending notifications for job ${statusChangeResult.monitor.id}: ${
+								error instanceof Error ? error.message : "Unknown error"
+							}`,
 							service: SERVICE_NAME,
 							method: "getMonitorJob",
 							stack: error instanceof Error ? error.stack : undefined,
@@ -168,15 +180,55 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 					});
 				}
 
-				// Step 7. Handle incidents (best effort, don't wait)
-				this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status).catch((error: unknown) => {
-					this.logger.warn({
-						message: `Error handling incident for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
-						service: SERVICE_NAME,
-						method: "getMonitorJob",
-						stack: error instanceof Error ? error.stack : undefined,
-					});
-				});
+				// Step 8. Handle incidents and capture the active/resolved incident
+				let incident = await this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status);
+
+				if (!incident && (statusChangeResult.monitor.status === "down" || statusChangeResult.monitor.status === "breached")) {
+					incident = await this.incidentsRepository.findActiveByMonitorId(statusChangeResult.monitor.id, statusChangeResult.monitor.teamId);
+				}
+
+				// Step 9. Handle escalated notification once per active incident
+				if (
+					incident &&
+					incident.status === true &&
+					statusChangeResult.monitor.escalation?.channelId &&
+					statusChangeResult.monitor.escalation?.delayMinutes
+				) {
+					const startedAt = new Date(incident.startTime).getTime();
+					const delayMs = statusChangeResult.monitor.escalation.delayMinutes * 60 * 1000;
+					const isDue = Date.now() - startedAt >= delayMs;
+					const notSentYet = !incident.escalatedAt;
+
+					if (isDue && notSentYet) {
+						this.logger.info({
+							message: `Escalation due for monitor ${statusChangeResult.monitor.id}`,
+							service: SERVICE_NAME,
+							method: "getMonitorJob",
+							details: {
+								startTime: incident.startTime,
+								delayMinutes: statusChangeResult.monitor.escalation.delayMinutes,
+								channelId: statusChangeResult.monitor.escalation.channelId,
+								escalatedAt: incident.escalatedAt,
+							},
+						});
+						this.notificationsService
+							.sendEscalation(statusChangeResult.monitor, status, decision)
+							.then(async () => {
+								incident.escalatedAt = new Date().toISOString();
+								await this.incidentsRepository.updateById(incident.id, incident.teamId, incident);
+							})
+							.catch((error: unknown) => {
+								this.logger.warn({
+									message: `Error sending escalation for job ${statusChangeResult.monitor.id}: ${
+										error instanceof Error ? error.message : "Unknown error"
+									}`,
+									service: SERVICE_NAME,
+									method: "getMonitorJob",
+									stack: error instanceof Error ? error.stack : undefined,
+								});
+							});
+					}
+				}
 			} catch (error: unknown) {
 				this.logger.warn({
 					message: error instanceof Error ? error.message : "Unknown error",

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -80,6 +80,9 @@ export class EmailProvider implements INotificationProvider {
 	private buildSubject(message: NotificationMessage): string {
 		switch (message.type) {
 			case "monitor_down":
+				if (message.metadata.notificationReason === "escalation") {
+					return `Escalation: Monitor ${message.monitor.name} still down`;
+				}
 				return `Monitor ${message.monitor.name} is down`;
 			case "monitor_up":
 				return `Monitor ${message.monitor.name} is back up`;

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,6 +14,7 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	sendEscalation: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -81,7 +82,6 @@ export class NotificationsService implements INotificationsService {
 			return false;
 		}
 
-		// Route to provider based on notification type
 		switch (notification.type) {
 			case "webhook":
 				return await this.webhookProvider.sendMessage!(notification, notificationMessage);
@@ -107,11 +107,18 @@ export class NotificationsService implements INotificationsService {
 		}
 	};
 
-	private sendNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
-		const notificationIds = monitor.notifications ?? [];
+	private sendNotificationsToIds = async (
+		notificationIds: string[],
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		decision: MonitorActionDecision
+	) => {
+		if (!notificationIds.length) {
+			return false;
+		}
+
 		const notifications = await this.notificationsRepository.findNotificationsByIds(notificationIds);
 
-		// Build notification message once for all notifications
 		const settings = this.settingsService.getSettings();
 		const clientHost = settings.clientHost || "Host not defined";
 		const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, decision, clientHost);
@@ -121,15 +128,21 @@ export class NotificationsService implements INotificationsService {
 		const outcomes = await Promise.all(tasks);
 		const succeeded = outcomes.filter(Boolean).length;
 		const failed = outcomes.length - succeeded;
+
 		if (failed > 0) {
 			this.logger.warn({
 				message: `Notification send completed with ${succeeded} success, ${failed} failure(s)`,
 				service: SERVICE_NAME,
-				method: "sendNotifications",
+				method: "sendNotificationsToIds",
 			});
 		}
-		// Return true if all notifications succeeded
+
 		return succeeded === notifications.length;
+	};
+
+	private sendNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
+		const notificationIds = monitor.notifications ?? [];
+		return await this.sendNotificationsToIds(notificationIds, monitor, monitorStatusResponse, decision);
 	};
 
 	handleNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
@@ -137,8 +150,60 @@ export class NotificationsService implements INotificationsService {
 			return false;
 		}
 
-		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	sendEscalation = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
+		const channelId = monitor.escalation?.channelId;
+
+		if (!channelId) {
+			return false;
+		}
+
+		const notifications = await this.notificationsRepository.findNotificationsByIds([channelId]);
+
+		if (!notifications.length) {
+			return false;
+		}
+
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+		const delayMinutes = monitor.escalation?.delayMinutes ?? 0;
+
+		const notificationMessage: NotificationMessage = {
+			type: "monitor_down",
+			severity: "critical",
+			monitor: {
+				id: monitor.id,
+				name: monitor.name,
+				url: monitor.url,
+				type: monitor.type,
+				status: monitor.status,
+			},
+			content: {
+				title: `Escalation: Monitor ${monitor.name} still down`,
+				summary: `Monitor "${monitor.name}" has remained down for ${delayMinutes} minute(s).`,
+				details: [
+					`URL: ${monitor.url}`,
+					`Status: ${monitor.status}`,
+					`Type: ${monitor.type}`,
+					`Escalation delay: ${delayMinutes} minute(s)`,
+					...(monitorStatusResponse.code ? [`Response Code: ${monitorStatusResponse.code}`] : []),
+					...(monitorStatusResponse.message ? [`Error: ${monitorStatusResponse.message}`] : []),
+				],
+				timestamp: new Date(),
+			},
+			clientHost,
+			metadata: {
+				teamId: monitor.teamId,
+				notificationReason: "escalation",
+			},
+		};
+
+		const tasks = notifications.map((notification) => this.send(notification, monitor, monitorStatusResponse, decision, notificationMessage));
+
+		const outcomes = await Promise.all(tasks);
+		return outcomes.every(Boolean);
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -12,6 +12,7 @@ export interface Incident {
 	status: boolean;
 	message?: string | null;
 	statusCode?: number | null;
+	escalatedAt?: string | null;
 	resolutionType: IncidentResolutionType;
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -56,6 +56,12 @@ export interface Monitor {
 	recentChecks: CheckSnapshot[];
 	createdAt: string;
 	updatedAt: string;
+	escalation?: MonitorEscalation | null;
+}
+
+export interface MonitorEscalation {
+	delayMinutes: number;
+	channelId: string;
 }
 
 export interface MonitorsSummary {

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -67,6 +67,13 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalation: z
+		.object({
+			delayMinutes: z.number().min(1),
+			channelId: z.string().min(1),
+		})
+		.nullable()
+		.optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +96,13 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalation: z
+		.object({
+			delayMinutes: z.number().min(1),
+			channelId: z.string().min(1),
+		})
+		.nullable()
+		.optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),
@@ -144,6 +158,13 @@ const importedMonitorSchema = z.object({
 	interval: z.number().default(60000),
 	uptimePercentage: z.number().optional(),
 	notifications: z.array(z.string()).default([]),
+	escalation: z
+		.object({
+			delayMinutes: z.number().min(1),
+			channelId: z.string().min(1),
+		})
+		.nullable()
+		.optional(),
 	secret: z.string().optional(),
 	cpuAlertThreshold: z.number().default(100),
 	cpuAlertCounter: z.number().default(5),


### PR DESCRIPTION
## Describe your changes

Implemented escalated notifications for monitors in the Checkmate codebase.

This update adds a new escalated notification configuration to the monitor form, including a delay in minutes and a separate escalation channel. The escalation settings are validated on both the frontend and backend, saved with the monitor, and persist when the monitor is reopened. On the backend, incident tracking and queue handling were updated so that an escalation email is sent once when a monitor remains down past the configured delay. I also updated email handling so escalation emails use a distinct subject line.

## Write your issue number after "Fixes "

Fixes #1

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>