### PR TITLE
Escalation added

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalationNotifications: data?.escalationNotifications || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -765,6 +765,140 @@ const CreateMonitorPage = () => {
 				}
 			/>
 
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalationNotifications.title")}
+				subtitle={t("pages.createMonitor.form.escalationNotifications.description")}
+				rightContent={
+					<Controller
+						name="escalationNotifications"
+						control={control}
+						render={({ field, fieldState }) => {
+							const notificationOptions = (notifications ?? []).map((n) => ({
+								...n,
+								name: n.notificationName,
+							}));
+
+							const selectedNotifications = notificationOptions.filter((n) =>
+								(field.value ?? []).some((entry) => entry.notificationId === n.id)
+							);
+
+							const selectedEscalations = (field.value ?? [])
+								.map((entry) => ({
+									entry,
+									notification: notificationOptions.find(
+										(option) => option.id === entry.notificationId
+									),
+								}))
+								.filter((item) => Boolean(item.notification));
+
+							return (
+								<Stack spacing={theme.spacing(LAYOUT.MD)}>
+									<Autocomplete
+										multiple
+										options={notificationOptions}
+										value={selectedNotifications}
+										fieldLabel={t(
+											"pages.createMonitor.form.escalationNotifications.option.channel.label"
+										)}
+										getOptionLabel={(option) => option.name}
+										onChange={(_: unknown, newValue: typeof notificationOptions) => {
+											const existingDelayById = new Map(
+												(field.value ?? []).map((entry) => [entry.notificationId, entry.delayMinutes])
+											);
+
+											field.onChange(
+												newValue.map((item) => ({
+													notificationId: item.id,
+													delayMinutes: existingDelayById.get(item.id) ?? 15,
+												}))
+											);
+										}}
+										isOptionEqualToValue={(option, value) => option.id === value.id}
+									/>
+									{selectedEscalations.length > 0 && (
+										<Stack
+											flex={1}
+											width="100%"
+										>
+											{selectedEscalations.map(({ entry, notification }, index) => {
+												if (!notification) {
+													return null;
+												}
+
+												return (
+													<Stack
+														direction={{ xs: "column", md: "row" }}
+														alignItems={{ xs: "stretch", md: "center" }}
+														spacing={theme.spacing(SPACING.SM)}
+														key={notification.id}
+														width="100%"
+													>
+														<Stack flexGrow={1}>
+															<Typography variant="caption" color="text.secondary">
+																{t(
+																	"pages.createMonitor.form.escalationNotifications.option.channel.label"
+																)}
+															</Typography>
+															<Typography>{notification.notificationName}</Typography>
+														</Stack>
+														<Stack
+															direction="row"
+															alignItems="center"
+															spacing={theme.spacing(SPACING.SM)}
+														>
+															<TextField
+																type="number"
+																fieldLabel={t(
+																	"pages.createMonitor.form.escalationNotifications.option.delay.label"
+																)}
+																value={entry.delayMinutes}
+																onChange={(e) => {
+																	const nextValue = Math.max(1, Number(e.target.value) || 1);
+																	field.onChange(
+																		(field.value ?? []).map((item) =>
+																			item.notificationId === notification.id
+																				? { ...item, delayMinutes: nextValue }
+																				: item
+																		)
+																	);
+																}}
+																sx={{ minWidth: { xs: "100%", md: 180 } }}
+															/>
+															<IconButton
+																size="small"
+																onClick={() => {
+																	field.onChange(
+																		(field.value ?? []).filter(
+																			(item) => item.notificationId !== notification.id
+																		)
+																	);
+																}}
+																aria-label="Remove escalation notification"
+															>
+																<Trash2 size={16} />
+															</IconButton>
+														</Stack>
+														{index < selectedEscalations.length - 1 && <Divider />}
+													</Stack>
+												);
+											})}
+										</Stack>
+									)}
+									{fieldState.error?.message && (
+										<Typography
+											color="error"
+											variant="caption"
+										>
+											{fieldState.error.message}
+										</Typography>
+									)}
+								</Stack>
+							);
+						}}
+					/>
+				}
+			/>
+
 			{(watchedType === "http" ||
 				watchedType === "grpc" ||
 				watchedType === "websocket") && (

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface MonitorEscalationNotification {
+	notificationId: string;
+	delayMinutes: number;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +65,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationNotifications?: MonitorEscalationNotification[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -13,6 +13,15 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalationNotifications: z.array(
+		z.object({
+			notificationId: z.string().min(1, "Escalation notification channel is required"),
+			delayMinutes: z
+				.number({ message: "Escalation delay is required" })
+				.int("Escalation delay must be a whole number")
+				.min(1, "Escalation delay must be at least 1 minute"),
+		})
+	),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -543,6 +543,18 @@
 					"description": "Select the notification channels you want to use",
 					"title": "Notifications"
 				},
+				"escalationNotifications": {
+					"title": "Escalation Notifications",
+					"description": "Choose channels for follow-up alerts if the monitor is still down after a delay.",
+					"option": {
+						"channel": {
+							"label": "Notification channel"
+						},
+						"delay": {
+							"label": "Escalation delay (minutes)"
+						}
+					}
+				},
 				"type": {
 					"description": "Select the type of check to perform",
 					"optionDockerDescription": "Use Docker to monitor if a container is running.",

--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -234,6 +234,7 @@ export const initializeServices = async ({
 	const notificationsService = new NotificationsService(
 		notificationsRepository,
 		monitorsRepository,
+		incidentsRepository,
 		webhookProvider,
 		emailProvider,
 		slackProvider,

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -18,11 +18,12 @@ type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Dat
 
 type MonitorDocumentBase = Omit<
 	Monitor,
-	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
+	"id" | "userId" | "teamId" | "notifications" | "escalationNotifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
 > & {
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
+	escalationNotifications: { notificationId: Types.ObjectId; delayMinutes: number }[];
 	selectedDisks: string[];
 	matchMethod?: MonitorMatchMethod;
 };
@@ -198,6 +199,22 @@ const checkSnapshotSchema = new Schema<CheckSnapshotDocument>(
 	{ _id: false }
 );
 
+const escalationNotificationSchema = new Schema<{ notificationId: Types.ObjectId; delayMinutes: number }>(
+	{
+		notificationId: {
+			type: Schema.Types.ObjectId,
+			ref: "Notification",
+			required: true,
+		},
+		delayMinutes: {
+			type: Number,
+			required: true,
+			min: 1,
+		},
+	},
+	{ _id: false }
+);
+
 const MonitorSchema = new Schema<MonitorDocument>(
 	{
 		userId: {
@@ -284,6 +301,10 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalationNotifications: {
+			type: [escalationNotificationSchema],
+			default: [],
+		},
 		secret: {
 			type: String,
 		},

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -17,7 +17,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		if (!monitors.length) {
 			return [];
 		}
-		const payload = monitors.map((monitor) => ({ ...monitor, notifications: undefined }));
+		const payload = monitors.map((monitor) => ({ ...monitor, notifications: undefined, escalationNotifications: undefined }));
 		try {
 			const inserted = await MonitorModel.insertMany(payload, { ordered: false });
 			return this.mapDocuments(inserted);
@@ -351,6 +351,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification) => toStringId(notification));
+		const escalationNotifications = (doc.escalationNotifications ?? []).map((item) => ({
+			notificationId: toStringId(item.notificationId),
+			delayMinutes: item.delayMinutes,
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -374,6 +378,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalationNotifications,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -410,6 +415,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification: unknown) => toStringId(notification));
+		const escalationNotifications = (doc.escalationNotifications ?? []).map((item) => ({
+			notificationId: toStringId(item.notificationId),
+			delayMinutes: item.delayMinutes,
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -433,6 +442,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalationNotifications,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -15,6 +15,7 @@ export interface INotificationMessageBuilder {
 		decision: MonitorActionDecision,
 		clientHost: string
 	): NotificationMessage;
+	buildEscalationMessage(monitor: Monitor, downForMinutes: number, clientHost: string): NotificationMessage;
 	extractThresholdBreaches(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): ThresholdBreach[];
 }
 
@@ -52,6 +53,38 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		};
 	}
 
+	buildEscalationMessage(monitor: Monitor, downForMinutes: number, clientHost: string): NotificationMessage {
+		const downForLabel = this.formatDownDuration(downForMinutes);
+
+		return {
+			type: "monitor_down_escalation",
+			severity: "critical",
+			monitor: {
+				id: monitor.id,
+				name: monitor.name,
+				url: monitor.url,
+				type: monitor.type,
+				status: monitor.status,
+			},
+			content: {
+				title: `Escalation: ${monitor.name} is still down`,
+				summary: `Monitor "${monitor.name}" is still down after ${downForLabel}.`,
+				details: [
+					`URL: ${monitor.url}`,
+					`Status: Down`,
+					`Type: ${monitor.type}`,
+					`Down for: ${downForLabel}`,
+				],
+				timestamp: new Date(),
+			},
+			clientHost,
+			metadata: {
+				teamId: monitor.teamId,
+				notificationReason: "escalation",
+			},
+		};
+	}
+
 	private determineNotificationType(decision: MonitorActionDecision, monitor: Monitor): NotificationType {
 		// Down status has highest priority (critical)
 		if (monitor.status === "down") {
@@ -80,6 +113,7 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	private determineSeverity(type: NotificationType): NotificationSeverity {
 		switch (type) {
 			case "monitor_down":
+			case "monitor_down_escalation":
 				return "critical";
 			case "threshold_breach":
 				return "warning";
@@ -96,6 +130,8 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	private buildContent(type: NotificationType, monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): NotificationContent {
 		switch (type) {
 			case "monitor_down":
+				return this.buildMonitorDownContent(monitor, monitorStatusResponse);
+			case "monitor_down_escalation":
 				return this.buildMonitorDownContent(monitor, monitorStatusResponse);
 			case "monitor_up":
 				return this.buildMonitorUpContent(monitor);
@@ -180,6 +216,20 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 			details: [`URL: ${monitor.url}`, `Status: ${monitor.status}`, `Type: ${monitor.type}`],
 			timestamp: new Date(),
 		};
+	}
+
+	private formatDownDuration(downForMinutes: number): string {
+		if (downForMinutes < 60) {
+			return `${downForMinutes} minute${downForMinutes === 1 ? "" : "s"}`;
+		}
+
+		const hours = Math.floor(downForMinutes / 60);
+		const minutes = downForMinutes % 60;
+		if (minutes === 0) {
+			return `${hours} hour${hours === 1 ? "" : "s"}`;
+		}
+
+		return `${hours} hour${hours === 1 ? "" : "s"} ${minutes} minute${minutes === 1 ? "" : "s"}`;
 	}
 
 	public extractThresholdBreaches(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse<HardwareStatusPayload>): ThresholdBreach[] {

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -81,6 +81,8 @@ export class EmailProvider implements INotificationProvider {
 		switch (message.type) {
 			case "monitor_down":
 				return `Monitor ${message.monitor.name} is down`;
+			case "monitor_down_escalation":
+				return `Escalation: ${message.monitor.name} is still down`;
 			case "monitor_up":
 				return `Monitor ${message.monitor.name} is back up`;
 			case "threshold_breach":

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -1,6 +1,6 @@
 import type { Monitor, MonitorStatusResponse, Notification } from "@/types/index.js";
 import type { NotificationMessage } from "@/types/notificationMessage.js";
-import { IMonitorsRepository, INotificationsRepository } from "@/repositories/index.js";
+import { IIncidentsRepository, IMonitorsRepository, INotificationsRepository } from "@/repositories/index.js";
 import { INotificationProvider } from "./notificationProviders/INotificationProvider.js";
 import type { MonitorActionDecision } from "@/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.js";
 import type { ISettingsService } from "@/service/system/settingsService.js";
@@ -26,6 +26,7 @@ export class NotificationsService implements INotificationsService {
 
 	private notificationsRepository: INotificationsRepository;
 	private monitorsRepository: IMonitorsRepository;
+	private incidentsRepository: IIncidentsRepository;
 	private webhookProvider: INotificationProvider;
 	private emailProvider: INotificationProvider;
 	private slackProvider: INotificationProvider;
@@ -36,10 +37,12 @@ export class NotificationsService implements INotificationsService {
 	private logger: ILogger;
 	private settingsService: ISettingsService;
 	private notificationMessageBuilder: INotificationMessageBuilder;
+	private escalationTimers: Map<string, ReturnType<typeof setTimeout>>;
 
 	constructor(
 		notificationsRepository: INotificationsRepository,
 		monitorsRepository: IMonitorsRepository,
+		incidentsRepository: IIncidentsRepository,
 		webhookProvider: INotificationProvider,
 		emailProvider: INotificationProvider,
 		slackProvider: INotificationProvider,
@@ -53,6 +56,7 @@ export class NotificationsService implements INotificationsService {
 	) {
 		this.notificationsRepository = notificationsRepository;
 		this.monitorsRepository = monitorsRepository;
+		this.incidentsRepository = incidentsRepository;
 		this.webhookProvider = webhookProvider;
 		this.emailProvider = emailProvider;
 		this.slackProvider = slackProvider;
@@ -63,15 +67,10 @@ export class NotificationsService implements INotificationsService {
 		this.settingsService = settingsService;
 		this.logger = logger;
 		this.notificationMessageBuilder = notificationMessageBuilder;
+		this.escalationTimers = new Map();
 	}
 
-	private send = async (
-		notification: Notification,
-		monitor: Monitor,
-		monitorStatusResponse: MonitorStatusResponse,
-		decision: MonitorActionDecision,
-		notificationMessage: NotificationMessage | undefined
-	): Promise<boolean> => {
+	private send = async (notification: Notification, notificationMessage: NotificationMessage | undefined): Promise<boolean> => {
 		if (!notificationMessage) {
 			this.logger.warn({
 				message: "Notification message not provided",
@@ -107,16 +106,13 @@ export class NotificationsService implements INotificationsService {
 		}
 	};
 
-	private sendNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
-		const notificationIds = monitor.notifications ?? [];
+	private sendNotificationsByIds = async (notificationIds: string[], notificationMessage: NotificationMessage) => {
 		const notifications = await this.notificationsRepository.findNotificationsByIds(notificationIds);
+		if (notifications.length === 0) {
+			return true;
+		}
 
-		// Build notification message once for all notifications
-		const settings = this.settingsService.getSettings();
-		const clientHost = settings.clientHost || "Host not defined";
-		const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, decision, clientHost);
-
-		const tasks = notifications.map((notification) => this.send(notification, monitor, monitorStatusResponse, decision, notificationMessage));
+		const tasks = notifications.map((notification) => this.send(notification, notificationMessage));
 
 		const outcomes = await Promise.all(tasks);
 		const succeeded = outcomes.filter(Boolean).length;
@@ -132,9 +128,92 @@ export class NotificationsService implements INotificationsService {
 		return succeeded === notifications.length;
 	};
 
+	private sendNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
+		const notificationIds = monitor.notifications ?? [];
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+		const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, decision, clientHost);
+
+		return await this.sendNotificationsByIds(notificationIds, notificationMessage);
+	};
+
+	private escalationTimerKey = (monitorId: string, notificationId: string) => `${monitorId}:${notificationId}`;
+
+	private clearEscalationTimersForMonitor = (monitorId: string) => {
+		for (const [key, timeoutId] of this.escalationTimers.entries()) {
+			if (!key.startsWith(`${monitorId}:`)) {
+				continue;
+			}
+
+			clearTimeout(timeoutId);
+			this.escalationTimers.delete(key);
+		}
+	};
+
+	private scheduleEscalations = async (monitor: Monitor) => {
+		const escalationNotifications = monitor.escalationNotifications ?? [];
+		if (escalationNotifications.length === 0) {
+			return;
+		}
+
+		for (const escalation of escalationNotifications) {
+			const delayMinutes = Number(escalation.delayMinutes);
+			if (!escalation.notificationId || !Number.isFinite(delayMinutes) || delayMinutes < 1) {
+				continue;
+			}
+
+			const timerKey = this.escalationTimerKey(monitor.id, escalation.notificationId);
+			if (this.escalationTimers.has(timerKey)) {
+				continue;
+			}
+
+			const timeoutId = setTimeout(async () => {
+				this.escalationTimers.delete(timerKey);
+
+				try {
+					const latestMonitor = await this.monitorsRepository.findById(monitor.id, monitor.teamId);
+					if (latestMonitor.status !== "down") {
+						return;
+					}
+
+					const activeIncident = await this.incidentsRepository.findActiveByMonitorId(latestMonitor.id, latestMonitor.teamId);
+					if (!activeIncident) {
+						return;
+					}
+
+					const startedAt = new Date(activeIncident.startTime).getTime();
+					const downForMinutes = Math.max(1, Math.floor((Date.now() - startedAt) / 60000));
+
+					const settings = this.settingsService.getSettings();
+					const clientHost = settings.clientHost || "Host not defined";
+					const escalationMessage = this.notificationMessageBuilder.buildEscalationMessage(latestMonitor, downForMinutes, clientHost);
+
+					await this.sendNotificationsByIds([escalation.notificationId], escalationMessage);
+				} catch (error: unknown) {
+					this.logger.error({
+						message: `Failed to send escalation notification for monitor ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+						service: SERVICE_NAME,
+						method: "scheduleEscalations",
+						stack: error instanceof Error ? error.stack : undefined,
+					});
+				}
+			}, delayMinutes * 60 * 1000);
+
+			this.escalationTimers.set(timerKey, timeoutId);
+		}
+	};
+
 	handleNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
 		if (!decision.shouldSendNotification) {
 			return false;
+		}
+
+		if (decision.shouldResolveIncident && monitor.status === "up") {
+			this.clearEscalationTimersForMonitor(monitor.id);
+		}
+
+		if (decision.shouldCreateIncident && monitor.status === "down") {
+			await this.scheduleEscalations(monitor);
 		}
 
 		// Send notifications based on decision

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface MonitorEscalationNotification {
+	notificationId: string;
+	delayMinutes: number;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +42,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationNotifications?: MonitorEscalationNotification[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/types/notificationMessage.ts
+++ b/server/src/types/notificationMessage.ts
@@ -3,7 +3,7 @@
  * Part of notification system unification effort
  */
 
-export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test";
+export type NotificationType = "monitor_down" | "monitor_up" | "monitor_down_escalation" | "threshold_breach" | "threshold_resolved" | "test";
 
 export type NotificationSeverity = "critical" | "warning" | "info" | "success";
 

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -3,6 +3,11 @@ import { booleanCoercion } from "./shared.js";
 import { GeoContinents } from "@/types/geoCheck.js";
 import { MonitorMatchMethods, MonitorTypes } from "@/types/monitor.js";
 
+const escalationNotificationValidation = z.object({
+	notificationId: z.string().min(1, "Escalation notification channel is required"),
+	delayMinutes: z.number().int().min(1, "Escalation delay must be at least 1 minute"),
+});
+
 export const getMonitorByIdParamValidation = z.object({
 	monitorId: z.string().min(1, "Monitor ID is required"),
 });
@@ -67,6 +72,7 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalationNotifications: z.array(escalationNotificationValidation).optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +95,7 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalationNotifications: z.array(escalationNotificationValidation).optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),
@@ -144,6 +151,7 @@ const importedMonitorSchema = z.object({
 	interval: z.number().default(60000),
 	uptimePercentage: z.number().optional(),
 	notifications: z.array(z.string()).default([]),
+	escalationNotifications: z.array(escalationNotificationValidation).default([]),
 	secret: z.string().optional(),
 	cpuAlertThreshold: z.number().default(100),
 	cpuAlertCounter: z.number().default(5),


### PR DESCRIPTION

Added support for notification escalations on monitors. This change adds a new escalation configuration field with `delayMinutes` and `channelId`, updates the monitor create/edit UI so users can add escalation rules, persists those rules in the backend, and adds helper logic to trigger the escalation notification channel once an incident has remained active past the configured delay.


Fixes #1
- [x ] I deployed the application locally.
- [x ]  I have performed a self-review and testing of my code.
- [x ] I have included the issue # in the PR.
- [x ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x ] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x ] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x ] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x ] My PR is granular and targeted to one specific feature.
- [ x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.

