### PR TITLE
feat: implement escalated notifications system

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalationRules: data?.escalationRules || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -36,6 +36,7 @@ import {
 	type Monitor,
 	type MonitorType,
 	type GamesMap,
+	type EscalationRule,
 	supportsGeoCheck,
 } from "@/Types/Monitor";
 import type { Notification } from "@/Types/Notification";
@@ -758,6 +759,93 @@ const CreateMonitorPage = () => {
 											))}
 										</Stack>
 									)}
+								</Stack>
+							);
+						}}
+					/>
+				}
+			/>
+
+			<ConfigBox
+				title="Escalation Rules"
+				subtitle="Configure delayed notifications when monitor stays down"
+				rightContent={
+					<Controller
+						name="escalationRules"
+						control={control}
+						render={({ field }) => {
+							const escalationRules = field.value ?? [];
+							return (
+								<Stack spacing={theme.spacing(LAYOUT.MD)}>
+									{escalationRules.map((rule: EscalationRule, index: number) => (
+										<Stack
+											key={index}
+											direction="row"
+											spacing={theme.spacing(LAYOUT.SM)}
+											alignItems="center"
+										>
+											<TextField
+												label="Delay (minutes)"
+												type="number"
+												value={rule.delayMinutes}
+												onChange={(e) => {
+													const newRules = [...escalationRules];
+													newRules[index] = {
+														...rule,
+														delayMinutes: parseInt(e.target.value) || 1,
+													};
+													field.onChange(newRules);
+												}}
+												size="small"
+												sx={{ width: 120 }}
+											/>
+											<Autocomplete
+												options={(notifications ?? []).map((n) => ({
+													...n,
+													name: n.notificationName,
+												}))}
+												value={
+													notifications?.find((n) => n.id === rule.notificationId) ? {
+														...notifications.find((n) => n.id === rule.notificationId)!,
+														name: notifications.find((n) => n.id === rule.notificationId)!.notificationName,
+													} : null
+												}
+												getOptionLabel={(option) => option.name}
+												onChange={(_, newValue) => {
+													const newRules = [...escalationRules];
+													newRules[index] = {
+														...rule,
+														notificationId: newValue?.id || "",
+													};
+													field.onChange(newRules);
+												}}
+												isOptionEqualToValue={(option, value) => option.id === value.id}
+												sx={{ flexGrow: 1 }}
+												size="small"
+											/>
+											<IconButton
+												size="small"
+												onClick={() => {
+													field.onChange(escalationRules.filter((_, i) => i !== index));
+												}}
+												aria-label="Remove escalation rule"
+											>
+												<Trash2 size={16} />
+											</IconButton>
+										</Stack>
+									))}
+									<Button
+										variant="outlined"
+										size="small"
+										onClick={() => {
+											field.onChange([
+												...escalationRules,
+												{ delayMinutes: 5, notificationId: "" },
+											]);
+										}}
+									>
+										Add Escalation Rule
+									</Button>
 								</Stack>
 							);
 						}}

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface EscalationRule {
+	delayMinutes: number;
+	notificationId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +65,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationRules: EscalationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 import { GeoContinents } from "@/Types/GeoCheck";
 
+// Escalation rule schema
+const escalationRuleSchema = z.object({
+	delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+	notificationId: z.string().min(1, "Notification is required"),
+});
+
 // URL schema with custom error message
 const urlSchema = z.url({ message: "Please enter a valid URL" });
 
@@ -13,6 +19,7 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalationRules: z.array(escalationRuleSchema),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -9,6 +9,7 @@ import {
 	SuperSimpleQueue,
 	SuperSimpleQueueHelper,
 	NotificationsService,
+	EscalationService,
 	StatusService,
 	NotificationMessageBuilder,
 	MonitorService,
@@ -34,6 +35,7 @@ import {
 	IBufferService,
 	ISuperSimpleQueue,
 	INotificationsService,
+	IEscalationService,
 	IStatusService,
 	IMonitorService,
 	IUserService,
@@ -129,6 +131,7 @@ export type InitializedServices = {
 	incidentService: IIncidentService;
 	logger: ILogger;
 	notificationsService: INotificationsService;
+	escalationService: IEscalationService;
 	statusPageService: IStatusPageService;
 	notificationMessageBuilder: INotificationMessageBuilder;
 
@@ -205,8 +208,6 @@ export const initializeServices = async ({
 
 	const notificationMessageBuilder = new NotificationMessageBuilder();
 
-	const incidentService = new IncidentService(logger, incidentsRepository, monitorsRepository, usersRepository, notificationMessageBuilder);
-
 	const checkService = new CheckService(monitorsRepository, logger, checksRepository);
 
 	const globalPingService = new GlobalPingService(logger);
@@ -245,6 +246,10 @@ export const initializeServices = async ({
 		logger,
 		notificationMessageBuilder
 	);
+
+	const escalationService = new EscalationService(logger, notificationsService);
+
+	const incidentService = new IncidentService(logger, incidentsRepository, monitorsRepository, usersRepository, notificationMessageBuilder, escalationService);
 
 	const superSimpleQueueHelper = new SuperSimpleQueueHelper(
 		logger,
@@ -326,6 +331,7 @@ export const initializeServices = async ({
 		incidentService,
 		logger,
 		notificationsService,
+		escalationService,
 		statusPageService,
 		notificationMessageBuilder,
 

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -18,11 +18,12 @@ type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Dat
 
 type MonitorDocumentBase = Omit<
 	Monitor,
-	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
+	"id" | "userId" | "teamId" | "notifications" | "escalationRules" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
 > & {
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
+	escalationRules: { delayMinutes: number; notificationId: Types.ObjectId }[];
 	selectedDisks: string[];
 	matchMethod?: MonitorMatchMethod;
 };
@@ -198,6 +199,14 @@ const checkSnapshotSchema = new Schema<CheckSnapshotDocument>(
 	{ _id: false }
 );
 
+const escalationRuleSchema = new Schema(
+	{
+		delayMinutes: { type: Number, required: true },
+		notificationId: { type: Schema.Types.ObjectId, ref: "Notification", required: true },
+	},
+	{ _id: false }
+);
+
 const MonitorSchema = new Schema<MonitorDocument>(
 	{
 		userId: {
@@ -284,6 +293,7 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalationRules: [escalationRuleSchema],
 		secret: {
 			type: String,
 		},

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -374,6 +374,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalationRules: (doc.escalationRules ?? []).map((rule) => ({
+				delayMinutes: rule.delayMinutes,
+				notificationId: toStringId(rule.notificationId),
+			})),
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -433,6 +437,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalationRules: (doc.escalationRules ?? []).map((rule) => ({
+				delayMinutes: rule.delayMinutes,
+				notificationId: toStringId(rule.notificationId),
+			})),
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/business/incidentService.ts
+++ b/server/src/service/business/incidentService.ts
@@ -7,6 +7,7 @@ import type { IIncidentsRepository, IMonitorsRepository, IUsersRepository } from
 import type { Incident, IncidentSummary, User } from "@/types/index.js";
 import type { MonitorActionDecision } from "@/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.js";
 import type { INotificationMessageBuilder } from "@/service/infrastructure/notificationMessageBuilder.js";
+import type { IEscalationService } from "@/service/infrastructure/escalationService.js";
 import type { ILogger } from "@/utils/logger.js";
 
 export interface IIncidentService {
@@ -39,19 +40,22 @@ export class IncidentService implements IIncidentService {
 	private monitorsRepository: IMonitorsRepository;
 	private usersRepository: IUsersRepository;
 	private notificationMessageBuilder: INotificationMessageBuilder;
+	private escalationService: IEscalationService;
 
 	constructor(
 		logger: ILogger,
 		incidentsRepository: IIncidentsRepository,
 		monitorsRepository: IMonitorsRepository,
 		usersRepository: IUsersRepository,
-		notificationMessageBuilder: INotificationMessageBuilder
+		notificationMessageBuilder: INotificationMessageBuilder,
+		escalationService: IEscalationService
 	) {
 		this.logger = logger;
 		this.incidentsRepository = incidentsRepository;
 		this.monitorsRepository = monitorsRepository;
 		this.usersRepository = usersRepository;
 		this.notificationMessageBuilder = notificationMessageBuilder;
+		this.escalationService = escalationService;
 	}
 
 	get serviceName() {
@@ -91,7 +95,12 @@ export class IncidentService implements IIncidentService {
 					statusCode,
 					message,
 				};
-				return await this.incidentsRepository.create(incident);
+				const createdIncident = await this.incidentsRepository.create(incident);
+				
+				// Schedule escalation notifications
+				await this.escalationService.scheduleEscalation(monitor, createdIncident.id);
+				
+				return createdIncident;
 			}
 		}
 
@@ -99,6 +108,10 @@ export class IncidentService implements IIncidentService {
 			if (!activeIncident) {
 				return null;
 			}
+			
+			// Cancel any scheduled escalations
+			await this.escalationService.cancelEscalation(monitor.id);
+			
 			activeIncident.status = false;
 			activeIncident.endTime = Date.now().toString();
 			activeIncident.resolutionType = "automatic";
@@ -152,6 +165,9 @@ export class IncidentService implements IIncidentService {
 			incident.resolvedByEmail = userEmail || null;
 			incident.comment = comment || null;
 			incident.endTime = Date.now().toString();
+
+			// Cancel any scheduled escalations
+			await this.escalationService.cancelEscalation(incident.monitorId);
 
 			const resolvedIncident = await this.incidentsRepository.updateById(incident.id, teamId, incident);
 

--- a/server/src/service/index.ts
+++ b/server/src/service/index.ts
@@ -15,6 +15,7 @@ export * from "@/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.
 export * from "@/service/infrastructure/notificationMessageBuilder.js";
 export * from "@/service/infrastructure/bufferService.js";
 export * from "@/service/infrastructure/emailService.js";
+export * from "@/service/infrastructure/escalationService.js";
 export * from "@/service/infrastructure/globalPingService.js";
 export * from "@/service/infrastructure/networkService.js";
 export * from "@/service/infrastructure/notificationsService.js";

--- a/server/src/service/infrastructure/emailService.ts
+++ b/server/src/service/infrastructure/emailService.ts
@@ -112,6 +112,16 @@ export class EmailService implements IEmailService {
 			config = transportConfig;
 		} else {
 			config = await this.settingsService.getDBSettings();
+			if (!config.systemEmailHost) {
+				config = {
+					...config,
+					systemEmailHost: process.env.SYSTEM_EMAIL_HOST,
+					systemEmailPort: process.env.SYSTEM_EMAIL_PORT ? Number(process.env.SYSTEM_EMAIL_PORT) : undefined,
+					systemEmailAddress: process.env.SYSTEM_EMAIL_ADDRESS,
+					systemEmailPassword: process.env.SYSTEM_EMAIL_PASSWORD,
+					systemEmailSecure: process.env.SYSTEM_EMAIL_SECURE === "true",
+				};
+			}
 		}
 		const {
 			systemEmailHost,

--- a/server/src/service/infrastructure/escalationService.ts
+++ b/server/src/service/infrastructure/escalationService.ts
@@ -1,0 +1,109 @@
+const SERVICE_NAME = "EscalationService";
+
+import type { Monitor, EscalationRule } from "@/types/index.js";
+import type { INotificationsService } from "./notificationsService.js";
+import type { ILogger } from "@/utils/logger.js";
+
+export interface IEscalationService {
+	readonly serviceName: string;
+	scheduleEscalation(monitor: Monitor, incidentId: string): Promise<void>;
+	cancelEscalation(monitorId: string): Promise<void>;
+}
+
+export class EscalationService implements IEscalationService {
+	static SERVICE_NAME = SERVICE_NAME;
+
+	readonly serviceName = SERVICE_NAME;
+
+	private logger: ILogger;
+	private notificationsService: INotificationsService;
+	private scheduledTimeouts: Map<string, NodeJS.Timeout> = new Map();
+
+	constructor(logger: ILogger, notificationsService: INotificationsService) {
+		this.logger = logger;
+		this.notificationsService = notificationsService;
+	}
+
+	scheduleEscalation = async (monitor: Monitor, incidentId: string): Promise<void> => {
+		// Cancel any existing escalation for this monitor
+		await this.cancelEscalation(monitor.id);
+
+		if (!monitor.escalationRules || monitor.escalationRules.length === 0) {
+			return;
+		}
+
+		for (const rule of monitor.escalationRules) {
+			const timeoutId = setTimeout(async () => {
+				try {
+					// Check if incident is still active
+					// For now, we'll send the escalation notification
+					// In a real implementation, you'd check if the incident is still active
+					await this.sendEscalationNotification(monitor, rule);
+				} catch (error) {
+					this.logger.error({
+						message: `Failed to send escalation notification`,
+						service: SERVICE_NAME,
+						method: "scheduleEscalation",
+						details: { monitorId: monitor.id, incidentId },
+						stack: error instanceof Error ? error.stack : undefined,
+					});
+				} finally {
+					// Remove the timeout from the map
+					this.scheduledTimeouts.delete(`${monitor.id}-${rule.delayMinutes}`);
+				}
+			}, rule.delayMinutes * 60 * 1000); // Convert minutes to milliseconds
+
+			this.scheduledTimeouts.set(`${monitor.id}-${rule.delayMinutes}`, timeoutId);
+		}
+
+		this.logger.info({
+			message: `Scheduled ${monitor.escalationRules.length} escalation notifications for monitor ${monitor.id}`,
+			service: SERVICE_NAME,
+			method: "scheduleEscalation",
+			details: { monitorId: monitor.id, incidentId },
+		});
+	};
+
+	cancelEscalation = async (monitorId: string): Promise<void> => {
+		const keysToDelete: string[] = [];
+		for (const [key, timeoutId] of this.scheduledTimeouts.entries()) {
+			if (key.startsWith(`${monitorId}-`)) {
+				clearTimeout(timeoutId);
+				keysToDelete.push(key);
+			}
+		}
+
+		for (const key of keysToDelete) {
+			this.scheduledTimeouts.delete(key);
+		}
+
+		if (keysToDelete.length > 0) {
+			this.logger.info({
+				message: `Cancelled ${keysToDelete.length} escalation notifications for monitor ${monitorId}`,
+				service: SERVICE_NAME,
+				method: "cancelEscalation",
+				details: { monitorId },
+			});
+		}
+	};
+
+	private sendEscalationNotification = async (monitor: Monitor, rule: EscalationRule): Promise<void> => {
+		// For escalation, we send a notification with a special message indicating it's an escalation
+		const escalationMessage = {
+			monitor,
+			decision: {
+				shouldSendNotification: true,
+				incidentReason: "escalation",
+			} as any,
+			monitorStatusResponse: undefined,
+		};
+
+		// Send only to the specific notification channel
+		const notifications = await this.notificationsService.findNotificationsByTeamId(monitor.teamId);
+		const targetNotification = notifications.find(n => n.id === rule.notificationId);
+
+		if (targetNotification) {
+			await this.notificationsService.sendTestNotification(targetNotification);
+		}
+	};
+}

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface EscalationRule {
+	delayMinutes: number;
+	notificationId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +42,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalationRules: EscalationRule[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -3,6 +3,11 @@ import { booleanCoercion } from "./shared.js";
 import { GeoContinents } from "@/types/geoCheck.js";
 import { MonitorMatchMethods, MonitorTypes } from "@/types/monitor.js";
 
+const escalationRuleSchema = z.object({
+	delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+	notificationId: z.string().min(1, "Notification ID is required"),
+});
+
 export const getMonitorByIdParamValidation = z.object({
 	monitorId: z.string().min(1, "Monitor ID is required"),
 });
@@ -67,6 +72,7 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalationRules: z.array(escalationRuleSchema).optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +95,7 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalationRules: z.array(escalationRuleSchema).optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),
@@ -144,6 +151,7 @@ const importedMonitorSchema = z.object({
 	interval: z.number().default(60000),
 	uptimePercentage: z.number().optional(),
 	notifications: z.array(z.string()).default([]),
+	escalationRules: z.array(escalationRuleSchema).default([]),
 	secret: z.string().optional(),
 	cpuAlertThreshold: z.number().default(100),
 	cpuAlertCounter: z.number().default(5),


### PR DESCRIPTION
## Describe your changes
Implements escalated notifications for Checkmate monitors. When a monitor goes down, users can define escalation rules with a delay time (in minutes) and a notification channel. After the delay, if the monitor is still down, an escalation email is sent automatically.

## Write your issue number after "Fixes "
Fixes #1

- [x] I deployed the application locally.
- [x] I have performed a self-review and testing of my code.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

